### PR TITLE
Use NuGet package in NUnit Library Project template

### DIFF
--- a/MonoDevelop.FSharpBinding/Templates/FSharpNUnitLibraryProject.xpt.xml
+++ b/MonoDevelop.FSharpBinding/Templates/FSharpNUnitLibraryProject.xpt.xml
@@ -32,9 +32,12 @@
 				<Reference type="Gac" refto="FSharp.Core, Version=4.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
 				<Reference type="Package" refto="System, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
 				<Reference type="Package" refto="System.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-				<Reference type="Package" refto="nunit.framework" SpecificVersion = "false" LocalCopy = "false" />
 			</References>
-		
+
+			<Packages>
+				<Package id="NUnit" version="2.6.4" />
+			</Packages>
+
 			<Files>
 				<UnformattedFile name="Test.fs">
 <![CDATA[namespace ${Namespace}


### PR DESCRIPTION
Fixes [bug #30073](https://bugzilla.xamarin.com/show_bug.cgi?id=30073) - NuGet package not added automatically in F# NUnit Library Project template.

The project template now installs the NUnit 2.6.4 NuGet package instead of using NUnit.Framework from the Gac. This makes the template consistent with the other NUnit Library Project templates in MonoDevelop.