### PR TITLE
Right align tooltips

### DIFF
--- a/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
+++ b/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj.orig
@@ -117,6 +117,7 @@
     <Compile Include="IndentationTrackerTests.fs" />
     <Compile Include="FSharpUnitTestTextEditorExtensionTests.fs" />
     <Compile Include="SemanticHighlighting.fs" />
+    <Compile Include="TestTooltipProvider.fs" />
   </ItemGroup>
   <PropertyGroup>
     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/MonoDevelop.FSharp.Tests/TestTooltipProvider.fs
+++ b/MonoDevelop.FSharp.Tests/TestTooltipProvider.fs
@@ -1,0 +1,88 @@
+﻿namespace MonoDevelopTests
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open System.Text.RegularExpressions
+open NUnit.Framework
+open FsUnit
+open MonoDevelop.FSharp
+
+[<TestFixture>]
+type TestTooltipProvider() =
+    inherit TestBase()
+
+    let stripHtml html = 
+        Regex.Replace(html, "<.*?>", "")
+
+    let htmlDecode (s: string) =
+        s.Replace("&lt;", "<")
+         .Replace("&gt;", ">")
+         .Replace("&apos;", "'")
+
+    let getTooltip source displayName =  
+        let checker = FSharpChecker.Create()
+
+        let file = "test.fsx"
+
+        let projOptions = 
+            checker.GetProjectOptionsFromScript(file, source)
+                |> Async.RunSynchronously
+
+        let allSymbols =
+            async {
+                let! pfr, cfa = checker.ParseAndCheckFileInProject(file, 0, source, projOptions)
+                match cfa with
+                | FSharpCheckFileAnswer.Succeeded cfr ->
+                    let! symbols = cfr.GetAllUsesOfAllSymbolsInFile() 
+                    return Some symbols
+                | _ -> return None } |> Async.RunSynchronously
+
+        let symbol =
+            match allSymbols with
+            | Some symbols -> symbols |> Seq.tryFind (fun s -> s.Symbol.DisplayName.StartsWith(displayName))
+            | None -> None
+        
+
+        let tooltip = SymbolTooltips.getTooltipFromSymbolUse symbol.Value
+
+        let signature =
+            match tooltip with
+            | ToolTip (tip, _) -> tip
+            | _ ->  ""
+
+        signature |> stripHtml |> htmlDecode
+
+    [<Test>]
+    member this.Formats_tooltip_arrows_right_aligned() =
+        let input = 
+            """
+            open System
+            let toBePartiallyApplied (datNumba: int) (thaString: string) (be: bool) =
+                ()
+            """
+        let allEqual coll = Seq.forall2 (fun elem1 elem2 -> elem1 = elem2) coll
+        let signature = getTooltip input "toBePartiallyApplied"
+
+        let expected = """val toBePartiallyApplied :
+   datNumba : int    ->
+   thaString: string ->
+   be       : bool   
+           -> unit"""
+
+        signature.ToString() |> should equal expected
+
+    [<Test>]
+    member this.Formats_forall2_tooltip_arrows_right_aligned() =
+        let input = 
+            """
+            open System
+            let allEqual coll = Seq.forall2 (fun elem1 elem2 -> elem1 = elem2) coll
+            """
+        
+        let signature = getTooltip input "forall2"
+
+        let expected = """val forall2 :
+   predicate: 'T1 -> 'T2 -> bool ->
+   source1  : seq<'T1>           ->
+   source2  : seq<'T2>           
+           -> bool"""
+
+        signature.ToString() |> should equal expected

--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -414,10 +414,10 @@ module SymbolTooltips =
 
             let allParams =
                 allParamsLengths
-                |> List.map(fun p -> let (paramTypes, length) = p 
-                                     paramTypes
-                                     |> List.map(fun p -> formatName indent padLength p ++ asType UserType (parameterTypeWithPadding p length))
-                                     |> String.concat (asType Symbol " *" ++ "\n"))
+                |> List.map(fun (paramTypes, length) ->
+                                paramTypes
+                                |> List.map(fun p -> formatName indent padLength p ++ asType UserType (parameterTypeWithPadding p length))
+                                |> String.concat (asType Symbol " *" ++ "\n"))
                 |> String.concat (asType Symbol "->" + "\n")
             
             let typeArguments =

--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -363,7 +363,7 @@ module SymbolTooltips =
             func.CurriedParameterGroups 
             |> Seq.map Seq.toList 
             |> Seq.toList 
-        
+
         let retType =
             //This try block will be removed when FCS updates
             try 
@@ -550,7 +550,7 @@ module SymbolTooltips =
             let signature = getFuncSignature symbol.DisplayContext func 3 false
             let summary = getSummaryFromSymbol func
             ToolTip(signature, summary)
-             
+
         | Function func ->
             let signature = getFuncSignature symbol.DisplayContext func 3 false
             ToolTip(signature, getSummaryFromSymbol func) 


### PR DESCRIPTION
Right aligns arrows (->) in tooltips. Fixes https://bugzilla.xamarin.com/show_bug.cgi?id=33098