### PR TITLE
These changes allow the language serve to report error when a partial failure occurs

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -85,7 +85,7 @@ type FSharpParser() =
                 let projectFile = proj |> function null -> filePath | proj -> proj.FileName.ToString()
                 let! results = languageService.ParseAndCheckFileInProject(projectFile, filePath, 0, content.Text, isObsolete)
 
-                results.GetErrors() |> Option.iter (Array.map formatError >> doc.AddRange)
+                results.GetErrors() |> (Seq.map formatError >> doc.AddRange)
 
                 //Try creating tokens
                 try


### PR DESCRIPTION
Not all of the language service features require that the parse and type
check results are both present.  So here we split the operations where
we can and allow errors to propagate on a type check failure which
results in an abort message fro the compiler.  Previously we would just
get no errors in the IDE and a spurious build failed during compile.