### PR TITLE
Add more logging

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -726,6 +726,7 @@ module SymbolTooltips =
                 let signature = getEntitySignature symbol.DisplayContext fse
                 ToolTip(signature, getSummaryFromSymbol fse)
             with exn ->
+                MonoDevelop.Core.LoggingService.LogWarning (sprintf "getTooltipFromSymbolUse: Error occured processing %A" fse)
                 ToolTips.EmptyTip
 
         | Constructor func ->

--- a/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
@@ -48,9 +48,9 @@ type FSharpTooltipProvider() =
 
       let isTokenInvalid = 
         match caretToken with
-        | Some token -> token.ColorClass = FSharpTokenColorKind.Comment ||
-                        token.ColorClass = FSharpTokenColorKind.String ||
-                        token.ColorClass = FSharpTokenColorKind.Text
+        | Some token -> token.CharClass = FSharpTokenCharKind.Comment ||
+                        token.CharClass = FSharpTokenCharKind.String ||
+                        token.CharClass = FSharpTokenCharKind.Text
         | None -> true
 
       if isTokenInvalid then null else 
@@ -93,7 +93,10 @@ type FSharpTooltipProvider() =
                       let textSeg = Symbols.getTextSegment editor s col lineStr
                       let tooltipItem = TooltipItem(tip, textSeg)
                       return Tooltip tooltipItem
-                    | EmptyTip -> return NoToolTipText //TODO Support non symbol tooltips?
+                    | EmptyTip ->
+                      //TODO Support non symbol tooltips?
+                      //Those currently being: '=', '->', '::'
+                      return NoToolTipText
                   | None -> return NoToolTipData
                 | None -> return ParseAndCheckNotFound
 
@@ -105,8 +108,12 @@ type FSharpTooltipProvider() =
 
       match result with
       | ParseAndCheckNotFound -> LoggingService.LogWarning "TooltipProvider: ParseAndCheckResults not found"; null
-      | NoToolTipText -> LoggingService.LogWarning "TooltipProvider: TootipText not returned"; null
-      | NoToolTipData -> LoggingService.LogWarning "TooltipProvider: No symbol data found"; null
+      | NoToolTipText -> sprintf "TooltipProvider: TootipText not returned\n   %s\n   %s" lineStr (String.replicate col "-" + "^")
+                         |> LoggingService.LogDebug
+                         null
+      | NoToolTipData -> sprintf "TooltipProvider: No symbol data found\n   %s\n   %s" lineStr (String.replicate col "-" + "^")
+                         |> LoggingService.LogDebug
+                         null
       | Tooltip t -> t
      
     with exn ->


### PR DESCRIPTION
Use char enum on the tokeniser to detect comment and strings better.
The colour enum returns default for most symbols, and default is the
same as Text!!!