### PR TITLE
Fix sematic highlighting tests

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -16,6 +16,7 @@ open System.Threading
 type FSharpParsedDocument(fileName) = 
     inherit DefaultParsedDocument(fileName)
     member val Tokens = None with get,set
+    member val AllSymbolUses = None with get,set
 
 // An instance of this type is created by MonoDevelop (as defined in the .xml for the AddIn) 
 type FSharpParser() = 
@@ -102,6 +103,10 @@ type FSharpParser() =
                   doc.Tokens <- Some(tokens)
                 with ex ->
                   LoggingService.LogWarning ("FSharpParser: Couldn't update token information", ex)
+                
+                //Get all the symboluses now rather than in semantic highlighting
+                let! allSymbolUses = results.GetAllUsesOfAllSymbolsInFile()
+                doc.AllSymbolUses <- allSymbolUses
 
                 //Set code folding regions, GetNavigationItems may throw in some situations
                 try 

--- a/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -487,7 +487,6 @@ type FSharpTextEditorCompletion() =
 //    result
 
   // Run completion automatically when the user hits '.'
-  // (this means that completion currently also works in comments and strings...)
   override x.HandleCodeCompletionAsync(context, completionChar, token) =
     if completionChar <> '.' then null else
     let computation = 


### PR DESCRIPTION
Also revert fix for (>.>) segments as it breaks preprocessor tokens.