### PR TITLE
Use msgpack to serialise project options

### DIFF
--- a/CompilerService/CompilerService.fsproj
+++ b/CompilerService/CompilerService.fsproj
@@ -94,45 +94,81 @@
   <Choose>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v3.5'">
       <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net35\FsPickler.dll</HintPath>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\net35-client\MsgPack.dll</HintPath>
           <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Runtime.Serialization">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Xml">
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
     </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.0')">
       <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net40\FsPickler.dll</HintPath>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\net40-client\MsgPack.dll</HintPath>
           <Private>True</Private>
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Runtime.Serialization">
-          <Paket>True</Paket>
-        </Reference>
-        <Reference Include="System.Xml">
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>
     </When>
     <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And ($(TargetFrameworkVersion) == 'v4.5' Or $(TargetFrameworkVersion) == 'v4.5.1' Or $(TargetFrameworkVersion) == 'v4.5.2' Or $(TargetFrameworkVersion) == 'v4.5.3' Or $(TargetFrameworkVersion) == 'v4.6')">
       <ItemGroup>
-        <Reference Include="FsPickler">
-          <HintPath>..\packages\FsPickler\lib\net45\FsPickler.dll</HintPath>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\net45\MsgPack.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="System.Runtime.Serialization">
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoAndroid'">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\MonoAndroid10\MsgPack.dll</HintPath>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
-        <Reference Include="System.Xml">
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'MonoTouch'">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\MonoTouch10\MsgPack.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Silverlight' And $(TargetFrameworkVersion) == 'v5.0'">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\sl5\MsgPack.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'WindowsPhone' And ($(TargetFrameworkVersion) == 'v8.0' Or $(TargetFrameworkVersion) == 'v8.1')">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\windowsphone8\MsgPack.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == 'Xamarin.iOS'">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\Xamarin.iOS10\MsgPack.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="($(TargetFrameworkIdentifier) == 'WindowsPhoneApp') Or ($(TargetFrameworkIdentifier) == '.NETCore') Or ($(TargetFrameworkIdentifier) == 'Xamarin.Mac') Or ($(TargetFrameworkProfile) == 'Profile7') Or ($(TargetFrameworkProfile) == 'Profile32') Or ($(TargetFrameworkProfile) == 'Profile44') Or ($(TargetFrameworkProfile) == 'Profile111') Or ($(TargetFrameworkProfile) == 'Profile151')">
+      <ItemGroup>
+        <Reference Include="MsgPack">
+          <HintPath>..\packages\MsgPack.Cli\lib\portable-net45+win+wpa81\MsgPack.dll</HintPath>
+          <Private>True</Private>
           <Paket>True</Paket>
         </Reference>
       </ItemGroup>

--- a/CompilerService/Program.fs
+++ b/CompilerService/Program.fs
@@ -1,8 +1,10 @@
 ﻿open System
+open System.IO
+open System.Collections
 open Nessos.Argu
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Reflection
-open Nessos.FsPickler
+open MsgPack.Serialization
 
 type Arguments =
   | Project of string
@@ -20,9 +22,9 @@ let main argv =
     let projectFile = results.GetResult(<@ Project @>)
     let checker = FSharpChecker.Create()
     let fsharpProjectOptions = checker.GetProjectOptionsFromProjectFile(projectFile)
-    let pickler = FsPickler.CreateBinarySerializer()
+    let serializer = SerializationContext.Default.GetSerializer<FSharpProjectOptions>()
     let outstream = Console.OpenStandardOutput()
-    pickler.Serialize(outstream, fsharpProjectOptions)
+    serializer.Pack(outstream, fsharpProjectOptions)
     0
   with ex ->
     Console.Out.WriteLine(ex)

--- a/CompilerService/paket.references
+++ b/CompilerService/paket.references
@@ -1,3 +1,3 @@
 Argu
 FSharp.Compiler.Service
-FsPickler
+MsgPack.Cli

--- a/MonoDevelop.FSharp.Tests/paket.references
+++ b/MonoDevelop.FSharp.Tests/paket.references
@@ -2,4 +2,4 @@ ExtCore
 FSharp.Compiler.Service
 Mono.Cecil
 NUnit
-FSPickler
+MsgPack.Cli

--- a/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -8,6 +8,7 @@ open ExtCore
 open ExtCore.Control
 open ExtCore.Control.Collections
 open MonoDevelop.Core
+open MsgPack.Serialization
 
 module Symbol =
   /// We always know the text of the identifier that resolved to symbol.
@@ -315,10 +316,10 @@ type LanguageService(dirtyNotify) =
 
             let started = proc.Start()
             let exited = proc.WaitForExit(ServiceSettings.maximumTimeout)
-            let binarySer =  Nessos.FsPickler.FsPickler.CreateBinarySerializer()
-            let optsNew = binarySer.Deserialize<FSharpProjectOptions>(proc.StandardOutput.BaseStream)
+    
+            let serializer = SerializationContext.Default.GetSerializer<FSharpProjectOptions>()
 
-            //let opts = checker.GetProjectOptionsFromProjectFile(projFilename, properties)
+            let optsNew = serializer.Unpack(proc.StandardOutput.BaseStream)
             projectInfoCache := cache.Add (key, optsNew)
             optsNew
           with ex -> LoggingService.LogDebug("LanguageService: GetProjectCheckerOptions Exception: {0}", ex.ToString())

--- a/MonoDevelop.FSharpBinding/paket.references
+++ b/MonoDevelop.FSharpBinding/paket.references
@@ -2,4 +2,4 @@ ExtCore
 Fantomas
 FSharp.Compiler.CodeDom
 Mono.Cecil
-FSPickler
+MsgPack.Cli

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -1,7 +1,7 @@
 source https://nuget.org/api/v2/
 
 nuget ExtCore framework: >= net40
-nuget FSPickler
+nuget MsgPack.Cli
 nuget FSharp.Compiler.Service
 nuget Fantomas framework: >= net45
 nuget FSharp.Compiler.CodeDom 0.9.2 framework: >= net40

--- a/paket.lock
+++ b/paket.lock
@@ -8,6 +8,6 @@ NUGET
       FSharp.Compiler.Service (>= 1.4.0.5)
     FSharp.Compiler.CodeDom (0.9.2) - framework: >= net40
     FSharp.Compiler.Service (1.4.2.1)
-    FsPickler (1.5.2)
     Mono.Cecil (0.9.6.1) - framework: >= net40
+    MsgPack.Cli (0.6.5)
     NUnit (2.6.4) - framework: >= net45


### PR DESCRIPTION
This should make us less susceptible to breakage in binary
serialisation versioning by the runtime team