### PR TITLE
Add  GetStringFormatterColours to language service

### DIFF
--- a/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -182,6 +182,11 @@ type ParseAndCheckResults (infoOpt : FSharpCheckFileResults option, parseResults
       | Some checkResults -> Some(checkResults.GetExtraColorizationsAlternate())
       | None -> None
 
+    member x.GetStringFormatterColours() =
+      match infoOpt with
+      | Some checkResults -> Some(checkResults.GetFormatSpecifierLocations())
+      | None -> None
+
 [<RequireQualifiedAccess>]
 type AllowStaleResults = 
   // Allow checker results where the source doesn't even match


### PR DESCRIPTION
To add this we would need to split string tokens into fragments
comprising of the formatted string parts and the rest of the string