### PR TITLE
Optimise parse

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
@@ -354,17 +354,14 @@ type FSharpSyntaxMode(editor, context) =
     }
 
   override x.DocumentParsed() =
-    match IdeApp.Workbench.ActiveDocument with
-    | null -> ()
-    | doc when doc.FileName = FilePath.Null || doc.FileName <> editor.FileName -> ()
-    | _doc ->
-
+    if MonoDevelop.isDocumentVisible context.Name then
       LoggingService.LogDebug "F# semantic highlighting - DocumentParsed"
       let processedTokens = x.GetProcessedTokens()
       processedTokens |> Option.iter (fun _ ->
                            LoggingService.LogDebug "F# semantic highlighting - DocumentParsed applying coloured segments"
                            segments <- processedTokens
                            Gtk.Application.Invoke(fun _ _ -> x.NotifySemanticHighlightingUpdate()))
+
 
   override x.GetColoredSegments(segment) = 
     let line = editor.GetLineByOffset segment.Offset

--- a/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -47,6 +47,21 @@ module MonoDevelop =
            | null -> MonoDevelop.Projects.ConfigurationSelector.Default
            | config -> config
 
+    let visibleDocuments() = 
+      IdeApp.Workbench.Documents
+      |> Seq.filter (fun doc -> match doc.Window with
+                                | :? Gtk.Widget as w -> w.HasScreen
+                                | _ -> false )
+
+    let isDocumentVisible filename =
+      visibleDocuments() 
+      |> Seq.exists (fun d -> d.FileName.ToString() = filename)
+
+    let tryGetVisibleDocument filename =
+      visibleDocuments() 
+      |> Seq.tryFind (fun d -> d.FileName.ToString() = filename)
+
+
 /// Provides functionality for working with the F# interactive checker running in background
 type MDLanguageService() =
   /// Single instance of the language service. We don't want the VFS during tests, so set it to blank from tests


### PR DESCRIPTION
Cancellation also checks visible open documents, if a document is
closed or made not visible the type check is cancelled.