### PR TITLE
Fixes cmd-d and cmd-r keybindings

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -157,6 +157,7 @@
     <Class fileExtensions = ".fs,.fsi,.fsx" class = "MonoDevelop.FSharp.HighlightUsagesExtension" />
     <Class fileExtensions = ".fs" class = "MonoDevelop.FSharp.FSharpUnitTestTextEditorExtension" />
     <Class fileExtensions = ".fs" class = "MonoDevelop.FSharp.FSharpOutlineTextEditorExtension" />
+		<Class class = "MonoDevelop.FSharp.FSharpCommandsTextEditorExtension" />
   </Extension>
 
   <Extension path = "/MonoDevelop/Ide/CodeTemplates">

--- a/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -157,7 +157,7 @@
     <Class fileExtensions = ".fs,.fsi,.fsx" class = "MonoDevelop.FSharp.HighlightUsagesExtension" />
     <Class fileExtensions = ".fs" class = "MonoDevelop.FSharp.FSharpUnitTestTextEditorExtension" />
     <Class fileExtensions = ".fs" class = "MonoDevelop.FSharp.FSharpOutlineTextEditorExtension" />
-		<Class class = "MonoDevelop.FSharp.FSharpCommandsTextEditorExtension" />
+    <Class class = "MonoDevelop.FSharp.FSharpCommandsTextEditorExtension" />
   </Extension>
 
   <Extension path = "/MonoDevelop/Ide/CodeTemplates">

--- a/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -602,18 +602,18 @@ type FSharpCommandsTextEditorExtension () =
     override x.IsValidInContext (context) =
         context.Name <> null && MDLanguageService.SupportedFileName context.Name
 
-    [<CommandUpdateHandler(RefactoryCommands.GotoDeclaration)>]
+    [<CommandUpdateHandler("MonoDevelop.Refactoring.RefactoryCommands.GotoDeclaration")>]
     member x.GotoDeclarationCommand_Update(ci:CommandInfo) =
         GotoDeclarationHandler().UpdateCommandInfo (ci)
     
-    [<CommandHandler (RefactoryCommands.GotoDeclaration)>]
+    [<CommandHandler ("MonoDevelop.Refactoring.RefactoryCommands.GotoDeclaration")>]
     member x.GotoDeclarationCommand () =
         GotoDeclarationHandler().Run(x.Editor, x.DocumentContext)
         
-    [<CommandUpdateHandler(Commands.EditCommands.Rename)>]
+    [<CommandUpdateHandler("MonoDevelop.Ide.Commands.EditCommands.Rename")>]
     member x.RenameCommand_Update(ci:CommandInfo) =
         RenameHandler().UpdateCommandInfo (ci)
     
-    [<CommandHandler (Commands.EditCommands.Rename)>]
+    [<CommandHandler ("MonoDevelop.Ide.Commands.EditCommands.Rename")>]
     member x.RenameCommand () =
         RenameHandler().Run (x.Editor, x.DocumentContext)

--- a/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -166,11 +166,11 @@ module Refactoring =
     let jumpTo (editor:TextEditor, ctx:DocumentContext, symbolUse, location:Range.range) =
             match getSymbolDeclarationLocation symbolUse editor.FileName ctx.Project.ParentSolution with
             | SymbolDeclarationLocation.CurrentFile ->
-                IdeApp.Workbench.OpenDocument (Gui.FileOpenInformation (FilePath(location.FileName), ctx.Project, Line = location.StartLine, Column = location.StartColumn))
+                IdeApp.Workbench.OpenDocument (Gui.FileOpenInformation (FilePath(location.FileName), ctx.Project, Line = location.StartLine, Column = location.StartColumn + 1))
                 |> ignore
                 
             | SymbolDeclarationLocation.Projects (_projects, _isSymbolLocal) ->
-                IdeApp.Workbench.OpenDocument (Gui.FileOpenInformation (FilePath(location.FileName), ctx.Project, Line = location.StartLine, Column = location.StartColumn))
+                IdeApp.Workbench.OpenDocument (Gui.FileOpenInformation (FilePath(location.FileName), ctx.Project, Line = location.StartLine, Column = location.StartColumn + 1))
                 |> ignore
 
             | SymbolDeclarationLocation.External docId ->


### PR DESCRIPTION
Not really happy with this fix, but it makes it work.

For reasons that I don't quite understand the enums in the attributes
were being converted to ints and then failing the equality check [here](https://github.com/mono/monodevelop/blob/64f4de8eaaccc8f77209cb76e2b0bbd9e788202a/main/src/core/MonoDevelop.Ide/MonoDevelop.Components.Commands/CommandManager.cs#L1686)