### PR TITLE
Replace lexer

### DIFF
--- a/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
+++ b/MonoDevelop.FSharp.Tests/MonoDevelop.FSharp.Tests.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -20,8 +20,7 @@
     <OutputPath>bin\Debug</OutputPath>
     <DefineConstants>TRACE;DEBUG;$(DefineConstants)</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
-    <PlatformTarget>
-    </PlatformTarget>
+    <PlatformTarget></PlatformTarget>
     <ConsolePause>true</ConsolePause>
     <Optimize>false</Optimize>
     <Tailcalls>false</Tailcalls>
@@ -41,16 +40,11 @@
     <DefineConstants>$(DefineConstants)</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="pango-sharp">
-    </Reference>
-    <Reference Include="atk-sharp">
-    </Reference>
-    <Reference Include="gdk-sharp">
-    </Reference>
-    <Reference Include="gtk-sharp">
-    </Reference>
-    <Reference Include="glib-sharp">
-    </Reference>
+    <Reference Include="pango-sharp"></Reference>
+    <Reference Include="atk-sharp"></Reference>
+    <Reference Include="gdk-sharp"></Reference>
+    <Reference Include="gtk-sharp"></Reference>
+    <Reference Include="glib-sharp"></Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -136,6 +130,7 @@
     <Compile Include="TestProjectNodeCommandHandler.fs" />
     <Compile Include="ProjectCracking.fs" />
     <Compile Include="GlobalSearch.fs" />
+    <Compile Include="ParsingTests.fs" />
   </ItemGroup>
   <PropertyGroup>
     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)\FSharp\Microsoft.FSharp.Targets</FSharpTargetsPath>

--- a/MonoDevelop.FSharp.Tests/ParsingTests.fs
+++ b/MonoDevelop.FSharp.Tests/ParsingTests.fs
@@ -1,0 +1,38 @@
+﻿namespace MonoDevelopTests
+open NUnit.Framework
+open FsUnit
+open MonoDevelop.FSharp
+
+[<TestFixture>]
+type ParsingTests() =
+  let checkGetSymbol col lineStr expected =
+    match Parsing.findLongIdents(col, lineStr)  with
+    | Some(_colu, ident) -> ident |> should equal [expected]
+    | None -> Assert.Fail "Could not find ident"
+      
+  let assertIdents (source: string) expected =
+    let col = source.IndexOf "|"
+    let source = source.Replace("|", "")
+    checkGetSymbol col source expected 
+    
+  let assertLongIdentsAndResidue (source: string) expectedIdent expectedResidue =
+    let col = source.IndexOf "|"
+    let source = source.Replace("|", "")
+    let ident, residue = Parsing.findLongIdentsAndResidue(col, source)
+    let expectedIdent = if expectedIdent = "" then [] else [expectedIdent]
+    ident |> should equal expectedIdent
+    residue |> should equal expectedResidue
+   
+  [<TestCase("let not|backticked = ", "notbackticked")>]
+  [<TestCase("open MonoDev|elop.FSharp", "MonoDevelop")>]
+  [<TestCase("open MonoDevelop.FSh|arp", "MonoDevelop.FSharp")>]
+  [<TestCase("open System.Te|xt.RegularExpressions", "System.Text")>]
+  member x.``Find long idents``(source: string, expected) =
+    assertIdents source expected
+    
+  [<TestCase("open MonoDevelop.FSh|", "MonoDevelop", "FSh")>]
+  [<TestCase("open MonoDev|", "", "MonoDev")>]
+  [<TestCase(" |  ", "", "")>]
+  [<TestCase("open |  ", "", "")>]
+  member x.``Find long idents and residue``(source: string, expectedIdent, expectedResidue) =
+    assertLongIdentsAndResidue source expectedIdent expectedResidue

--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -59,8 +59,7 @@
     <FSharpTargetsPath>$(MSBuildExtensionsPath32)\..\Microsoft SDKs\F#\3.0\Framework\v4.0\Microsoft.FSharp.Targets</FSharpTargetsPath>
   </PropertyGroup>
   <Import Project="$(FSharpTargetsPath)" Condition="Exists('$(FSharpTargetsPath)')" />
-  <Target Name="AfterBuild">
-  </Target>
+  <Target Name="AfterBuild"></Target>
   <Target Name="AfterClean">
     <RemoveDir Directories="$(OutputPath)\packages" />
   </Target>
@@ -69,6 +68,7 @@
   <ItemGroup>
     <Compile Include="Services\Extensions.fs" />
     <Compile Include="Services\CompilerLocationUtils.fs" />
+    <Compile Include="Services\Lexer.fs" />
     <Compile Include="Services\Parser.fs" />
     <Compile Include="Services\OrderAssemblyReferences.fs" />
     <Compile Include="Services\Parameters.fs" />

--- a/MonoDevelop.FSharpBinding/Services/Extensions.fs
+++ b/MonoDevelop.FSharpBinding/Services/Extensions.fs
@@ -82,6 +82,20 @@ module String =
                 if line.Length <= lineWidth then sb.AppendLine(line) |> ignore
                 else splitLine sb line lineWidth
             sb.ToString()
+            
+  let inline isNotNull v = not (isNull v)      
+  let getLines (str: string) =
+    use reader = new StringReader(str)
+    [|
+    let line = ref (reader.ReadLine())
+    while isNotNull (!line) do
+        yield !line
+        line := reader.ReadLine()
+    if str.EndsWith("\n") then
+        // last trailing space not returned
+        // http://stackoverflow.com/questions/19365404/stringreader-omits-trailing-linebreak
+        yield String.Empty
+    |]
 
 [<AutoOpen>]
 module FSharpSymbolExt =

--- a/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -8,6 +8,7 @@ open ExtCore
 open ExtCore.Control
 open ExtCore.Control.Collections
 open MonoDevelop.Core
+open MonoDevelop.Core
 open Nessos.FsPickler.Json
 
 module Symbol =

--- a/MonoDevelop.FSharpBinding/Services/Lexer.fs
+++ b/MonoDevelop.FSharpBinding/Services/Lexer.fs
@@ -1,0 +1,200 @@
+﻿namespace MonoDevelop.FSharp
+
+open System.Diagnostics
+open Microsoft.FSharp.Compiler.SourceCodeServices
+open MonoDevelop.Core
+
+type SymbolKind =
+    | Ident
+    | Operator
+    | GenericTypeParameter
+    | StaticallyResolvedTypeParameter
+    | Other
+
+type LexerSymbol =
+    { Kind: SymbolKind
+      Line: int
+      LeftColumn: int
+      RightColumn: int
+      Text: string }
+    member x.Range = x.Line, x.LeftColumn, x.Line, x.RightColumn
+
+[<RequireQualifiedAccess>]
+type SymbolLookupKind =
+    | Fuzzy
+    | ByRightColumn
+    | ByLongIdent
+
+type internal DraftToken =
+    { Kind: SymbolKind
+      Token: FSharpTokenInfo 
+      RightColumn: int }
+    static member inline Create kind token = 
+        { Kind = kind; Token = token; RightColumn = token.LeftColumn + token.FullMatchedLength - 1 }
+
+module Lexer =
+    /// Get the array of all lex states in current source
+    let internal getLexStates defines (source: string) =
+        [|
+            /// Iterate through the whole line to get the final lex state
+            let rec loop (lineTokenizer: FSharpLineTokenizer) lexState =
+                match lineTokenizer.ScanToken lexState with
+                | None, newLexState -> newLexState
+                | Some _, newLexState ->
+                    loop lineTokenizer newLexState
+
+            let sourceTokenizer = SourceTokenizer(defines, "/tmp.fsx")
+            let lines = String.getLines source
+            let lexState = ref 0L
+            for line in lines do 
+                yield !lexState
+                let lineTokenizer = sourceTokenizer.CreateLineTokenizer line
+                lexState := loop lineTokenizer !lexState
+        |]
+
+    // Provide a default implementation where we cache lex states of the current document.
+    // Assume that current document will be queried repeatedly
+    let queryLexState =
+        let currentDocumentState = ref None
+        fun source defines line ->
+            let lexStates = 
+                match !currentDocumentState with
+                | Some (lexStates, s, d) when s = source && d = defines ->
+                    lexStates
+                // OPTIMIZE: if the new document has the current document as a prefix, 
+                // we can reuse lexing results and process only the added part.
+                | _ ->
+                    LoggingService.LogDebug "queryLexState: lexing current document"
+                    let lexStates = getLexStates defines source
+                    currentDocumentState := Some (lexStates, source, defines) 
+                    lexStates
+            Debug.Assert(line >= 0 && line < Array.length lexStates, "Should have lex states for every line.")
+            lexStates.[line]
+
+    /// Return all tokens of current line
+    let tokenizeLine source (args: string[]) line lineStr queryLexState =
+        let defines =
+            args |> Seq.choose (fun s -> if s.StartsWith "--define:" then Some s.[9..] else None)
+                 |> Seq.toList
+        let sourceTokenizer = SourceTokenizer(defines, "/tmp.fsx")
+        let lineTokenizer = sourceTokenizer.CreateLineTokenizer lineStr
+        let rec loop lexState acc =
+            match lineTokenizer.ScanToken lexState with
+            | Some tok, state -> loop state (tok :: acc)
+            | _ -> List.rev acc
+        loop (queryLexState source defines line) []
+
+    // Returns symbol at a given position.
+    let getSymbolFromTokens (tokens: FSharpTokenInfo list) line col (lineStr: string) lookupKind: LexerSymbol option =
+        let isIdentifier t = t.CharClass = FSharpTokenCharKind.Identifier
+        let isOperator t = t.ColorClass = FSharpTokenColorKind.Operator
+    
+        let inline (|GenericTypeParameterPrefix|StaticallyResolvedTypeParameterPrefix|Other|) (token: FSharpTokenInfo) =
+            if token.Tag = FSharpTokenTag.QUOTE then GenericTypeParameterPrefix
+            elif token.Tag = FSharpTokenTag.INFIX_AT_HAT_OP then
+                 // The lexer return INFIX_AT_HAT_OP token for both "^" and "@" symbols.
+                 // We have to check the char itself to distinguish one from another.
+                 if token.FullMatchedLength = 1 && lineStr.[token.LeftColumn] = '^' then 
+                    StaticallyResolvedTypeParameterPrefix
+                 else Other
+            else Other
+
+       
+        // Operators: Filter out overlapped operators (>>= operator is tokenized as three distinct tokens: GREATER, GREATER, EQUALS. 
+        // Each of them has FullMatchedLength = 3. So, we take the first GREATER and skip the other two).
+        //
+        // Generic type parameters: we convert QUOTE + IDENT tokens into single IDENT token, altering its LeftColumn 
+        // and FullMathedLength (for "'type" which is tokenized as (QUOTE, left=2) + (IDENT, left=3, length=4) 
+        // we'll get (IDENT, left=2, length=5).
+        //
+        // Statically resolved type parameters: we convert INFIX_AT_HAT_OP + IDENT tokens into single IDENT token, altering its LeftColumn 
+        // and FullMathedLength (for "^type" which is tokenized as (INFIX_AT_HAT_OP, left=2) + (IDENT, left=3, length=4) 
+        // we'll get (IDENT, left=2, length=5).
+        let tokens = 
+            tokens
+            |> List.fold (fun (acc, lastToken) token ->
+                match lastToken with
+                | Some t when token.LeftColumn <= t.RightColumn -> acc, lastToken
+                | _ ->
+                    match token with
+                    | GenericTypeParameterPrefix -> acc, Some (DraftToken.Create GenericTypeParameter token)
+                    | StaticallyResolvedTypeParameterPrefix -> acc, Some (DraftToken.Create StaticallyResolvedTypeParameter token)
+                    | Other ->
+                        let draftToken =
+                            match lastToken with
+                            | Some { Kind = GenericTypeParameter | StaticallyResolvedTypeParameter as kind } when isIdentifier token ->
+                                DraftToken.Create kind { token with LeftColumn = token.LeftColumn - 1
+                                                                    FullMatchedLength = token.FullMatchedLength + 1 }
+                            | _ -> 
+                                let kind = if isOperator token then Operator elif isIdentifier token then Ident else Other
+                                DraftToken.Create kind token
+                        draftToken :: acc, Some draftToken
+                ) ([], None)
+            |> fst
+           
+        // One or two tokens that in touch with the cursor (for "let x|(g) = ()" the tokens will be "x" and "(")
+        let tokensUnderCursor = 
+            match lookupKind with
+            | SymbolLookupKind.Fuzzy ->
+                tokens |> List.filter (fun x -> x.Token.LeftColumn <= col && x.RightColumn + 1 >= col)
+            | SymbolLookupKind.ByRightColumn ->
+                tokens |> List.filter (fun x -> x.RightColumn = col)
+            | SymbolLookupKind.ByLongIdent ->
+                tokens |> List.filter (fun x -> x.Token.LeftColumn <= col)
+                
+        //printfn "Filtered tokens: %+A" tokensUnderCursor
+        match lookupKind with
+        | SymbolLookupKind.ByLongIdent ->
+            // Try to find start column of the long identifiers
+            // Assume that tokens are ordered in an decreasing order of start columns
+            let rec tryFindStartColumn tokens =
+               match tokens with
+               | {Kind = Ident; Token = t1} :: {Kind = Operator; Token = t2} :: remainingTokens ->
+                    if t2.Tag = FSharpTokenTag.DOT then
+                        tryFindStartColumn remainingTokens
+                    else
+                        Some t1.LeftColumn
+               | {Kind = Ident; Token = t} :: _ ->
+                   Some t.LeftColumn
+               | _ :: _ | [] ->
+                   None
+            let decreasingTokens =
+                match tokensUnderCursor |> List.sortBy (fun token -> - token.Token.LeftColumn) with
+                // Skip the first dot if it is the start of the identifier
+                | {Kind = Operator; Token = t} :: remainingTokens when t.Tag = FSharpTokenTag.DOT ->
+                    remainingTokens
+                | newTokens -> newTokens
+            
+            match decreasingTokens with
+            | [] -> None
+            | first :: _ ->
+                tryFindStartColumn decreasingTokens
+                |> Option.map (fun leftCol ->
+                    { Kind = Ident
+                      Line = line
+                      LeftColumn = leftCol
+                      RightColumn = first.RightColumn + 1
+                      Text = lineStr.[leftCol..first.RightColumn] })
+        | SymbolLookupKind.Fuzzy 
+        | SymbolLookupKind.ByRightColumn ->
+            // Select IDENT token. If failed, select OPERATOR token.
+            tokensUnderCursor
+            |> List.tryFind (fun { DraftToken.Kind = k } -> 
+                match k with 
+                | Ident | GenericTypeParameter | StaticallyResolvedTypeParameter -> true 
+                | _ -> false) 
+            |> Option.orTry (fun _ -> tokensUnderCursor |> List.tryFind (fun { DraftToken.Kind = k } -> k = Operator))
+            |> Option.map (fun token ->
+                { Kind = token.Kind
+                  Line = line
+                  LeftColumn = token.Token.LeftColumn
+                  RightColumn = token.RightColumn + 1
+                  Text = lineStr.Substring(token.Token.LeftColumn, token.Token.FullMatchedLength) })
+    
+    let getSymbol source line col lineStr lookupKind (args: string[]) queryLexState =
+        let tokens = tokenizeLine source args line lineStr queryLexState
+        try
+            getSymbolFromTokens tokens line col lineStr lookupKind
+        with e ->
+            LoggingService.LogInfo (sprintf "Getting lex symbols failed with %O" e)
+            None 

--- a/MonoDevelop.FSharpBinding/Services/Parser.fs
+++ b/MonoDevelop.FSharpBinding/Services/Parser.fs
@@ -1,324 +1,49 @@
-﻿// --------------------------------------------------------------------------------------
-// Simple monadic parser generator that we use in the IntelliSense
-// --------------------------------------------------------------------------------------
-
-#nowarn "40" // recursive references checked at runtime
-namespace MonoDevelop.FSharp
+﻿namespace MonoDevelop.FSharp
 
 open System
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler
 open System.Globalization
 open MonoDevelop.Core
-// --------------------------------------------------------------------------------------
-// Simple implementation of LazyList
-// --------------------------------------------------------------------------------------
-
-type LazyList<'T> =
-  | Nil
-  | Cons of 'T * Lazy<LazyList<'T>>
-
-[<CompilationRepresentation(CompilationRepresentationFlags.ModuleSuffix)>]
-module LazyList =
-  let ofSeq (s:seq<'T>) =
-    let en = s.GetEnumerator()
-    let rec take() =
-      if en.MoveNext() then
-        Cons(en.Current, lazy take())
-      else
-        en.Dispose()
-        Nil
-    take()
-
-module Parser =
-
-  open System
-
-  /// Parser is implemented using lazy list (so that we can use seq<_>)
-  type Parser<'T> = P of (LazyList<char> -> ('T * LazyList<char>) list)
-
-
-  // Basic functions needed by the computation builder
-
-  let result v = P(fun c -> [v, c])
-  let zero () = P(fun _ -> [])
-  let bind (P p) f = P(fun inp ->
-    [ for (pr, inp') in p inp do
-        let (P pars) = f pr
-        yield! pars inp' ])
-  let plus (P p) (P q) = P (fun inp ->
-    (p inp) @ (q inp) )
-
-  let (<|>) p1 p2 = plus p1 p2
-
-  type ParserBuilder() =
-    member x.Bind(v, f) = bind v f
-    member x.Zero() = zero()
-    member x.Return(v) = result(v)
-    member x.ReturnFrom(p) = p
-    member x.Combine(a, b) = plus a b
-    member x.Delay(f) = f()
-
-  let parser = new ParserBuilder()
-
-  // --------------------------------------------------------------------------------------
-  // Basic combinators for composing parsers
-
-  let item = P(function | LazyList.Nil -> [] | LazyList.Cons(c, r) -> [c,r.Value])
-
-  let sequence (P p) (P q) = P (fun inp -> 
-    [ for (pr, inp') in p inp do
-        for (qr, inp'') in q inp' do 
-          yield (pr, qr), inp''])
-
-  let sat p = parser { 
-    let! v = item 
-    if (p v) then return v }
-
-  let char x = sat ((=) x)
-  let digit = sat Char.IsDigit    
-  let lower = sat Char.IsLower
-  let upper = sat Char.IsUpper
-  let letter = sat Char.IsLetter
-  let nondigit = sat (Char.IsDigit >> not)
-  let whitespace = sat (Char.IsWhiteSpace)
-
-  let alphanum = parser { 
-    return! letter
-    return! digit }  
-
-  let rec word = parser {
-    return []
-    return! parser {
-      let! x = letter
-      let! xs = word
-      return x::xs } }
-
-  let string (str:string) = 
-    let chars = str.ToCharArray() |> List.ofSeq
-    let rec string' = function
-      | [] -> result []
-      | x::xs -> parser { 
-          let! y = char x
-          let! ys = string' xs 
-          return y::ys }
-    string' chars
-
-  let rec many p = parser {
-    return! parser { 
-      let! it = p
-      let! res = many p
-      return it::res } 
-    return [] }
-
-  let rec some p = parser {
-    let! first = p
-    let! rest = many p
-    return first::rest }
-
-  let rec map f p = parser { 
-    let! v = p 
-    return f v }
-
-  let optional p = parser {
-    return! parser { let! v = p in return Some v }
-    return None }             
-
-  let apply (P p) (str:seq<char>) = 
-    let res = str |> LazyList.ofSeq |> p
-    res |> List.map fst
 
 // --------------------------------------------------------------------------------------
 /// Parsing utilities for IntelliSense (e.g. parse identifier on the left-hand side
 /// of the current cursor location etc.)
 module Parsing =
-  open Parser
-  open System.Diagnostics
-
-  let inline isFirstOpChar ch =
-      ch = '!' || ch = '%'|| ch = '&' || ch = '*'|| ch = '+'|| ch = '-'|| ch = '.'|| ch = '/'|| ch = '<'|| ch = '='|| ch = '>'|| ch = '@'|| ch = '^'|| ch = '|'|| ch = '~'
-  let isOpChar ch = ch = '?' || isFirstOpChar ch
-      
-  let private symOpLits = [ "?"; "?<-"; "<@"; "<@@"; "@>"; "@@>" ]
-
-  let isSymbolicOp (str:string) =
-    List.exists ((=) str) symOpLits ||
-      (str.Length > 1 && isFirstOpChar str.[0] && Seq.forall isOpChar str.[1..])
-
-  let parseSymOpFragment = some (sat isOpChar)
-  let parseBackSymOpFragment = parser {
-    // This is unfortunate, but otherwise cracking at $ in A.$B
-    // causes the backward parse to return a symbol fragment.
-    let! c  = sat (fun c -> c <> '.' && isOpChar c)
-    let! cs = many (sat isOpChar)
-    return String.ofReversedSeq (c::cs)
-    }
-
-  let parseActivePatternEnd =
-    let rec aux = parser {
-      let! i = some (sat PrettyNaming.IsLongIdentifierPartCharacter)
-      let! p = char '|'
-      let! rest = parser { let! _ = char ')'
-                           return [] } <|> aux
-      return i@p::rest }
-    parser {
-      let! p = optional (char '|')
-      let! rest = aux
-      return if p.IsSome then p.Value::rest else rest
-    }
-  let fsharpIdentCharacter = sat PrettyNaming.IsIdentifierPartCharacter
-
-  /// Parses F# short-identifier (i.e. not including '.'); also ignores active patterns
-  let parseIdent =
-    parseActivePatternEnd <|> parseSymOpFragment <|> many fsharpIdentCharacter
-     |> map String.ofSeq
-
-
-  let rawIdChar = sat (fun c -> c <> '\n' && c <> '\t' && c <> '\r' && c <> '`')
-
-  let singleBackTick = parser {
-    let! _ = char '`'
-    let! x = rawIdChar
-    return ['`';x]
-  }
-
-  let rawIdCharAsString = parser {
-    let! x = rawIdChar
-    return [x]
-  }
-
-  // Parse a raw identifier backwards
-  let rawIdResidue = parser {
-    let! x = many (rawIdCharAsString <|> singleBackTick)
-    let! _ = string "``"
-    return List.concat x
-  }
-
-  /// Parse F# short-identifier and reverse the resulting string
-  let parseBackIdent =  
-    parser {
-        let! x = optional (string "``")
-        let! res = many (if x.IsSome then rawIdChar else fsharpIdentCharacter) |> map String.ofReversedSeq 
-        let! _ = optional (string "``")
-        return res }
-
-  /// Parse remainder of a long identifier before '.' (e.g. "Name.space.")
-  /// (designed to look backwards - reverses the results after parsing)
-  let rec parseBackLongIdentRest = parser {
-    return! parser {
-      let! _ = char '.'
-      let! ident = parseBackIdent
-      let! rest = parseBackLongIdentRest
-      return ident::rest }
-    return [] } 
-
-  /// Parse long identifier with raw residue (backwards) (e.g. "Debug.``A.B Hel")
-  /// and returns it as a tuple (reverses the results after parsing)
-  let parseBackIdentWithRawResidue = parser {
-    let! residue = rawIdResidue
-    let residue = String.ofReversedSeq residue
-    return! parser {
-      let! long = parseBackLongIdentRest
-      return residue, long |> List.rev }
-    return residue, [] }
-
-  /// Parse long identifier with residue (backwards) (e.g. "Debug.Wri")
-  /// and returns it as a tuple (reverses the results after parsing)
-  let parseBackIdentWithResidue = parser {
-    let! residue = many fsharpIdentCharacter 
-    let residue = String.ofReversedSeq residue
-    return! parser {
-      let! long = parseBackLongIdentRest
-      return residue, long |> List.rev }
-    return residue, [] }   
-
-  let parseBackIdentWithEitherResidue =
-    parseBackIdentWithResidue <|> parseBackIdentWithRawResidue
-
-  /// Parse long identifier and return it as a list (backwards, reversed)
-  let parseBackLongIdent = parser {
-    return! parser {
-      let! ident = parseBackSymOpFragment <|> parseBackIdent
-      let! rest = parseBackLongIdentRest
-      return ident::rest |> List.rev }
-    return [] }
-
-  let parseBackTriggerThenLongIdent = parser {
-    let! _ = (char '(' <|> char '<')
-    let! _  = many whitespace
-    return! parseBackLongIdent
-    }
-
-  /// Create sequence that reads the string backwards
-  let createBackStringReader (str:string) from = seq { 
-    for i in (min from (str.Length - 1)) .. -1 .. 0 do yield str.[i] }
-
-  /// Create sequence that reads the string forwards
-  let createForwardStringReader (str:string) from = seq { 
-    for i in (max 0 from) .. (str.Length - 1) do yield str.[i] }
-
-  /// Returns first result returned by the parser
-  let getFirst p s = apply p s |> List.head
-  let tryGetFirst p s = match apply p s with h::_ -> Some h | [] -> None
-   
-
   // Parsing - find the identifier around the current location
   // (we look for full identifier in the backward direction, but only
   // for a short identifier forward - this means that when you hover
   // 'B' in 'A.B.C', you will get intellisense for 'A.B' module)
   let findLongIdents (col, lineStr) = 
-    let lookBack = createBackStringReader lineStr (col-1)
-    let lookForw = createForwardStringReader lineStr col
-
-    let backIdentOpt = tryGetFirst parseBackLongIdent lookBack
-    match backIdentOpt with 
-    | None -> None 
-    | Some backIdent -> 
-    let nextIdentOpt = tryGetFirst parseIdent lookForw
-    match nextIdentOpt with 
-    | None -> None 
-    | Some nextIdent -> 
-
-    let identIsland =
-      match List.rev backIdent with
-      | last::prev -> 
-         let current = last + nextIdent
-         current::prev |> List.rev
-      | [] -> []
-
-    LoggingService.LogDebug("findLongIdents: at column:{0} Identifier:{1} Line:{2}", col, identIsland, lineStr)
-    
-    match identIsland with
-    | [] | [ "" ] -> None
-    | _ -> Some (col + nextIdent.Length,identIsland)
+    match Lexer.getSymbol lineStr 0 col lineStr SymbolLookupKind.ByLongIdent [||] Lexer.queryLexState with
+    | Some sym -> match sym.Text with
+                  | "" -> None
+                  | _ -> Some (sym.RightColumn, [sym.Text])
+    | _ -> None
     
   /// find the identifier prior to a '(' or ',' once the method tip trigger '(' shows
   let findLongIdentsAtGetMethodsTrigger (col, lineStr) = 
-    let lookBack = createBackStringReader lineStr col
-    let backIdentOpt = tryGetFirst parseBackTriggerThenLongIdent lookBack
-    match backIdentOpt with 
-    | None -> None 
-    | Some backIdent -> 
-
-    let identIsland =
-      match List.rev backIdent with
-      | last::prev -> (last::prev |> List.rev)
-      | [] -> []
-    
-    LoggingService.LogDebug("findLongIdentsAtGetMethodsTrigger: at column:{0} Identifier:{1} Line:{2}", col, identIsland, lineStr)
-    
-    match identIsland with
-    | [] | [ "" ] -> None
-    | _ -> Some (col,identIsland)
+    /// Create sequence that reads the string backwards
+    let createBackStringReader (str:string) from = seq { 
+      for i in (min from (str.Length-1)) .. -1 .. 0 do yield str.[i], i }
+      
+    let _char, index = createBackStringReader lineStr col
+                       |> Seq.takeWhile (fun (c, _index) -> c <> ')')
+                       |> Seq.head
+    match findLongIdents(index-1, lineStr) with
+    | Some (_col, ident) -> Some(col, ident)
+    | _ -> None
     
   /// Returns the previous long idents and the current 'residue'
   let findLongIdentsAndResidue (col, lineStr) =
-    let lookBack = createBackStringReader lineStr (col - 1)
-    let results = apply parseBackIdentWithEitherResidue lookBack
-    let residue, longName =
-        List.sortBy (fun (s,ss) -> String.length s + (List.sumBy String.length ss)) results
-        |> List.rev
-        |> List.head
-    LoggingService.LogDebug("findLongIdentsAndResidue: at column:{0} Line:{1} longname:{2} residue: {3}", col, lineStr, longName, residue)
-    longName, residue
+    match Lexer.getSymbol lineStr 0 col lineStr SymbolLookupKind.ByLongIdent [||] Lexer.queryLexState with
+    | Some sym -> match sym.Text with
+                  | "" -> [], String.empty
+                  | _ -> let res = sym.Text.Split '.' 
+                                   |> List.ofArray
+                                   |> List.rev
 
+                         match res with
+                         | head :: tail -> tail, head
+                         | [] -> [], ""
+    | _ -> [], String.empty


### PR DESCRIPTION
Backticks now work (goto def, tooltips, highlight usages) amongst other things. 

The new lexer (same one used in Visual F# Power Tools) has numerous bug fixes not found in the old parser.