### PR TITLE
fix project cracker from hanging on droid app

### DIFF
--- a/CompilerService/Program.fs
+++ b/CompilerService/Program.fs
@@ -21,10 +21,10 @@ let main argv =
     let outstream = Console.OpenStandardOutput()
 
     let (|Prefix|_|) (p:string) (s:string) =
-      if s.StartsWith(p) then
-          Some(s.Substring(p.Length))
-      else
-          None
+        if s.StartsWith(p) then
+            Some(s.Substring(p.Length))
+        else
+            None
 
     let normalizeOptions options =
         options
@@ -53,4 +53,7 @@ let main argv =
         with
         | ex -> Choice2Of2 ex
     pickler.Serialize(outstream, result)
+    // Workaround to ensure that all msbuild threads are terminated.
+    // Without this, it hangs on the default Xamarin.Forms Android app
+    Environment.Exit 0 
     0


### PR DESCRIPTION
Hacky, but simple fix to stop CompilerService.exe from hanging when running the project cracking against the default Xamarin.Forms Droid app.