### PR TITLE
Improved brace matching by using the compiler for ( and )

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
+++ b/MonoDevelop.FSharpBinding/FSharpBinding.addin.xml
@@ -151,6 +151,10 @@
     <Panel id = "FSharpFormatting" _label = "F# Formatting" mimeType="text/x-fsharp" class = "MonoDevelop.FSharp.FSharpFormattingPolicyPanel" />
   </Extension>
 
+  <Extension path = "/MonoDevelop/Ide/BraceMatcher">
+    <Class class="MonoDevelop.FSharp.FSharpBraceMatcher" />
+  </Extension>
+
   <Extension path = "/MonoDevelop/Ide/TextEditorExtensions">
     <Class fileExtensions=".fs,.fsi,.fsx,.fsscript" class="MonoDevelop.FSharp.FSharpTextEditorCompletion" />
     <Class fileExtensions = ".fs,.fsx" class = "MonoDevelop.FSharp.FSharpPathExtension" />

--- a/MonoDevelop.FSharpBinding/FSharpBraceMatcher.fs
+++ b/MonoDevelop.FSharpBinding/FSharpBraceMatcher.fs
@@ -1,0 +1,50 @@
+﻿namespace MonoDevelop.FSharp
+
+open System
+open MonoDevelop
+open MonoDevelop.Core.Text
+open MonoDevelop.Ide.Editor
+open Microsoft.FSharp.Compiler
+open Microsoft.FSharp.Compiler.SourceCodeServices
+
+type FSharpBraceMatcher() =
+    inherit AbstractBraceMatcher()
+    let defaultMatcher = new DefaultBraceMatcher()
+
+    override x.CanHandle editor =
+        MDLanguageService.SupportedFileName (editor.FileName.ToString())
+
+    override x.GetMatchingBracesAsync (editor, context, caretOffset, cancellationToken) =
+        match editor.GetCharAt(caretOffset) with
+        | '(' | ')' ->
+            match context.ParsedDocument.TryGetAst() with
+            | Some _ast -> 
+                let computation = async {
+                    let getOffset (range:Range.range) =
+                        editor.LocationToOffset (range.StartLine, range.StartColumn+1)
+
+                    let! braces = languageService.MatchingBraces(editor.FileName.ToString(), context.Project.FileName.ToString(), editor.Text)
+                    let matching = 
+                        braces |> Seq.choose
+                                      (fun (startRange, endRange) -> 
+                                          let startOffset = getOffset startRange
+                                          let endOffset = getOffset endRange
+                                          match (startOffset, endOffset) with
+                                          | (startOffset, endOffset) when startOffset = caretOffset 
+                                              -> Some (startOffset, endOffset, true)
+                                          | (startOffset, endOffset) when endOffset = caretOffset
+                                              -> Some (startOffset, endOffset, false)
+                                          | _ -> None)
+                               |> Seq.tryHead
+
+                    return
+                        match matching with
+                        | Some (startBrace, endBrace, isLeft) -> 
+                            Nullable(new BraceMatchingResult(new TextSegment(startBrace, 1), new TextSegment(endBrace, 1), isLeft))
+                        | None -> Nullable()
+
+                }
+                Async.StartAsTask (computation = computation, cancellationToken = cancellationToken)
+            | None -> defaultMatcher.GetMatchingBracesAsync (editor, context, caretOffset, cancellationToken)
+        | _ -> defaultMatcher.GetMatchingBracesAsync (editor, context, caretOffset, cancellationToken)
+        

--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -1,5 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -1,3 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -106,6 +107,7 @@
     <Compile Include="UnformattedTextFileDescriptionTemplate.fs" />
     <Compile Include="FakeSearchCategory.fs" />
     <Compile Include="FSharpNavigationTextEditorExtension.fs" />
+    <Compile Include="FSharpBraceMatcher.fs" />
     <EmbeddedResource Include="FSharpSyntaxMode.xml" />
     <EmbeddedResource Include="FSharpFormattingPolicy.xml" />
     <EmbeddedResource Include="FSharpStylePolicy.xml" />

--- a/MonoDevelop.FSharpBinding/Services/LanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/LanguageService.fs
@@ -494,6 +494,10 @@ type LanguageService(dirtyNotify) as x =
 
           return allSymbolUses }
 
+    member x.MatchingBraces(filename, projectFilename, source) =
+        let opts = x.GetCheckerOptions(filename, projectFilename, source)
+        checker.MatchBracesAlternate(filename, source, opts)
+
     /// Get all symbols derived from the specified symbol in the current project and optionally all dependent projects
     member x.GetDerivedSymbolsInProject(projectFilename, file, source, symbolAtCaret:FSharpSymbol, ?dependentProjects) =
         let predicate (symbolUse: FSharpSymbolUse) =


### PR DESCRIPTION
Makes bracket matching on code like `let x(   (*          *)  ) = ()` work