### PR TITLE
Move extension tests to own module.

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpBraceMatcher.fs
+++ b/MonoDevelop.FSharpBinding/FSharpBraceMatcher.fs
@@ -12,7 +12,7 @@ type FSharpBraceMatcher() =
     let defaultMatcher = new DefaultBraceMatcher()
 
     override x.CanHandle editor =
-        MDLanguageService.SupportedFileName (editor.FileName.ToString())
+        FileService.supportedFileName (editor.FileName.ToString())
 
     override x.GetMatchingBracesAsync (editor, context, caretOffset, cancellationToken) =
         let offset = Math.Min(caretOffset, editor.Text.Length - 1)

--- a/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
+++ b/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
@@ -48,7 +48,7 @@ type FSharpInteractivePad() as this =
     let mutable activeDoc : IDisposable option = None
 
     let getCorrectDirectory () =
-        if IdeApp.Workbench.ActiveDocument <> null && MDLanguageService.IsInsideFSharpFile() then
+        if IdeApp.Workbench.ActiveDocument <> null && FileService.isInsideFSharpFile() then
             let doc = IdeApp.Workbench.ActiveDocument.FileName.ToString()
             if doc <> null then Path.GetDirectoryName(doc) |> Some else None
         else None
@@ -286,7 +286,7 @@ type FSharpInteractivePad() as this =
 
     override x.Update(info:CommandInfo) =
         info.Enabled <- true
-        info.Visible <- MDLanguageService.IsInsideFSharpFile()
+        info.Visible <- FileService.isInsideFSharpFile()
     override x.Run() =
         FSharpInteractivePad.Fsi
         |> Option.iter (fun fsi -> command fsi

--- a/MonoDevelop.FSharpBinding/FSharpParser.fs
+++ b/MonoDevelop.FSharpBinding/FSharpParser.fs
@@ -133,7 +133,7 @@ type FSharpParser() =
 
         let doc = MonoDevelop.tryGetVisibleDocument fileName
 
-        if doc.IsNone || not (MDLanguageService.SupportedFileName (fileName)) then null else
+        if doc.IsNone || not (FileService.supportedFileName (fileName)) then null else
 
         let shortFilename = Path.GetFileName fileName
         LoggingService.LogDebug ("FSharpParser: Parse starting on {0}", shortFilename)

--- a/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -51,7 +51,7 @@ type FSharpProject() as self =
 
     let invalidateFiles (args:#ProjectFileEventInfo seq) =
         for projectFileEvent in args do
-            if MDLanguageService.SupportedFileName (projectFileEvent.ProjectFile.FilePath.ToString()) then
+            if FileService.supportedFileName (projectFileEvent.ProjectFile.FilePath.ToString()) then
                 invalidateProjectFile()
 
     let isPortable (project:MSBuildProject) =

--- a/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
@@ -52,7 +52,7 @@ type FSharpTooltipProvider() =
             let file = doc.FileName.FullPath.ToString()
             let projectFile = context.Project |> function null -> file | project -> project.FileName.ToString()
 
-            if not (MDLanguageService.SupportedFileName file) then noTooltip else
+            if not (FileService.supportedFileName file) then noTooltip else
 
             let source = editor.Text
             if source = null || offset >= source.Length || offset < 0 then noTooltip else

--- a/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
+++ b/MonoDevelop.FSharpBinding/RefactoringOperationsHandler.fs
@@ -418,7 +418,7 @@ type CurrentRefactoringOperationsHandler() =
         match tryGetValidDoc() with
         | None -> ()
         | Some doc ->
-            if not (MDLanguageService.SupportedFileName (doc.FileName.ToString())) then ()
+            if not (FileService.supportedFileName (doc.FileName.ToString())) then ()
             else
                 match doc.TryGetAst () with
                 | None -> ()
@@ -541,7 +541,7 @@ type FindReferencesHandler() =
     inherit CommandHandler()
 
     member x.Run (editor:TextEditor, ctx:DocumentContext) =
-        if MDLanguageService.SupportedFilePath editor.FileName then
+        if FileService.supportedFilePath editor.FileName then
             match ctx.TryGetAst() with
             | Some ast ->
                 match Refactoring.getSymbolAndLineInfoAtCaret ast editor with
@@ -562,7 +562,7 @@ type RenameHandler() =
         if editor = null || editor.FileName = FilePath.Null
         then ci.Bypass <- false
         else
-            if not (MDLanguageService.SupportedFilePath editor.FileName) then ci.Bypass <- true
+            if not (FileService.supportedFilePath editor.FileName) then ci.Bypass <- true
             else
                 match doc.TryGetAst() with
                 | Some ast ->
@@ -579,11 +579,11 @@ type RenameHandler() =
 
     override x.Run (_data) =
         let doc = IdeApp.Workbench.ActiveDocument
-        if doc <> null || doc.FileName <> FilePath.Null || not (MDLanguageService.SupportedFilePath doc.FileName) then
+        if doc <> null || doc.FileName <> FilePath.Null || not (FileService.supportedFilePath doc.FileName) then
             x.Run (doc.Editor, doc)
 
     member x.Run (editor:TextEditor, ctx:DocumentContext) =
-        if MDLanguageService.SupportedFilePath editor.FileName then
+        if FileService.supportedFilePath editor.FileName then
             match ctx.TryGetAst() with
             | Some ast ->
                 match Refactoring.getSymbolAndLineInfoAtCaret ast editor with
@@ -606,7 +606,7 @@ type GotoDeclarationHandler() =
         let editor = doc.Editor
         //skip if theres no editor or filename
         if editor = null || editor.FileName = FilePath.Null then ci.Bypass <- true
-        elif not (MDLanguageService.SupportedFilePath editor.FileName) then ci.Bypass <- true
+        elif not (FileService.supportedFilePath editor.FileName) then ci.Bypass <- true
         else
             match doc.TryGetAst() with
             | Some ast ->
@@ -620,11 +620,11 @@ type GotoDeclarationHandler() =
 
     override x.Run (_data) =
         let doc = IdeApp.Workbench.ActiveDocument
-        if doc <> null || doc.FileName <> FilePath.Null || not (MDLanguageService.SupportedFilePath doc.FileName) then
+        if doc <> null || doc.FileName <> FilePath.Null || not (FileService.supportedFilePath doc.FileName) then
             x.Run(doc.Editor, doc)
 
     member x.Run(editor, context:DocumentContext) =
-        if MDLanguageService.SupportedFileName (editor.FileName.ToString()) then
+        if FileService.supportedFileName (editor.FileName.ToString()) then
             match context.TryGetAst() with
             | Some ast ->
                 match Refactoring.getSymbolAndLineInfoAtCaret ast editor with
@@ -642,7 +642,7 @@ type FSharpJumpToDeclarationHandler () =
                 // We only need to run this when the editor isn't F#
                 match IdeApp.Workbench.ActiveDocument with
                 | null -> return false
-                | doc when MDLanguageService.SupportedFileName (doc.FileName.ToString()) -> return false
+                | doc when FileService.supportedFileName (doc.FileName.ToString()) -> return false
                 | _doc ->
                     let result =
                         Search.getAllSymbolsInAllProjects()
@@ -684,9 +684,11 @@ type FSharpFindReferencesProvider () =
 
 type FSharpCommandsTextEditorExtension () =
     inherit Editor.Extension.TextEditorExtension ()
+    static member SupportedFileExtensions =
+        [".fsscript"; ".fs"; ".fsx"; ".fsi"; ".sketchfs"]
 
     override x.IsValidInContext (context) =
-        context.Name <> null && MDLanguageService.SupportedFileName context.Name
+        context.Name <> null && FileService.supportedFileName context.Name
 
     [<CommandUpdateHandler("MonoDevelop.Refactoring.RefactoryCommands.GotoDeclaration")>]
     member x.GotoDeclarationCommand_Update(ci:CommandInfo) =

--- a/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -111,24 +111,25 @@ type MDLanguageService() =
   static member DisableVirtualFileSystem() =
       vfs <- lazy (Shim.FileSystem)
 
-  static member SupportedFileExtensions =
-      [".fsscript"; ".fs"; ".fsx"; ".fsi"; ".sketchfs"]
-
-  /// Is the specified extension supported F# file?
-  static member SupportedFileName fileName =
-      let ext = Path.GetExtension(fileName).ToLower()
-      MDLanguageService.SupportedFileExtensions
-      |> List.exists ((=) ext)
-
-  static member IsInsideFSharpFile () =
-      if IdeApp.Workbench.ActiveDocument = null ||
-        IdeApp.Workbench.ActiveDocument.FileName.FileName = null then false
-      else
-        let file = IdeApp.Workbench.ActiveDocument.FileName.ToString()
-        MDLanguageService.SupportedFileName (file)
-
-  static member SupportedFilePath (filePath:FilePath) =
-      MDLanguageService.SupportedFileName (filePath.ToString())
+module FileService =
+    let supportedFileExtensions =
+        [".fsscript"; ".fs"; ".fsx"; ".fsi"; ".sketchfs"]
+    
+    /// Is the specified extension supported F# file?
+    let supportedFileName fileName =
+        let ext = Path.GetExtension(fileName).ToLower()
+        supportedFileExtensions
+        |> List.exists ((=) ext)
+    
+    let isInsideFSharpFile () =
+        if IdeApp.Workbench.ActiveDocument = null ||
+            IdeApp.Workbench.ActiveDocument.FileName.FileName = null then false
+        else
+            let file = IdeApp.Workbench.ActiveDocument.FileName.ToString()
+            supportedFileName (file)
+    
+    let supportedFilePath (filePath:FilePath) =
+        supportedFileName (filePath.ToString())
 
 [<AutoOpen>]
 module MDLanguageServiceImpl =


### PR DESCRIPTION
This is because Windows machines without fsharp installed are trying
to instantiate the FCS virtual file system.