### PR TITLE
Move FileService so that MDLanguageService.Instance

### DIFF
--- a/MonoDevelop.FSharpBinding/Services/FileService.fs
+++ b/MonoDevelop.FSharpBinding/Services/FileService.fs
@@ -57,3 +57,24 @@ type FileSystem (defaultFileSystem : IFileSystem, openDocuments: unit -> Documen
         member x.FileDelete fileName = defaultFileSystem.FileDelete fileName
         member x.AssemblyLoadFrom fileName = defaultFileSystem.AssemblyLoadFrom fileName
         member x.AssemblyLoad(assemblyName) = defaultFileSystem.AssemblyLoad assemblyName
+
+module FileService =
+    let supportedFileExtensions =
+        [".fsscript"; ".fs"; ".fsx"; ".fsi"; ".sketchfs"]
+    
+    /// Is the specified extension supported F# file?
+    let supportedFileName fileName =
+        let ext = Path.GetExtension(fileName).ToLower()
+        supportedFileExtensions
+        |> List.exists ((=) ext)
+    
+    let isInsideFSharpFile () =
+        if IdeApp.Workbench.ActiveDocument = null ||
+            IdeApp.Workbench.ActiveDocument.FileName.FileName = null then false
+        else
+            let file = IdeApp.Workbench.ActiveDocument.FileName.ToString()
+            supportedFileName (file)
+    
+    let supportedFilePath (filePath:FilePath) =
+        supportedFileName (filePath.ToString())
+

--- a/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -111,26 +111,6 @@ type MDLanguageService() =
   static member DisableVirtualFileSystem() =
       vfs <- lazy (Shim.FileSystem)
 
-module FileService =
-    let supportedFileExtensions =
-        [".fsscript"; ".fs"; ".fsx"; ".fsi"; ".sketchfs"]
-    
-    /// Is the specified extension supported F# file?
-    let supportedFileName fileName =
-        let ext = Path.GetExtension(fileName).ToLower()
-        supportedFileExtensions
-        |> List.exists ((=) ext)
-    
-    let isInsideFSharpFile () =
-        if IdeApp.Workbench.ActiveDocument = null ||
-            IdeApp.Workbench.ActiveDocument.FileName.FileName = null then false
-        else
-            let file = IdeApp.Workbench.ActiveDocument.FileName.ToString()
-            supportedFileName (file)
-    
-    let supportedFilePath (filePath:FilePath) =
-        supportedFileName (filePath.ToString())
-
 [<AutoOpen>]
 module MDLanguageServiceImpl =
     let languageService = MDLanguageService.Instance


### PR DESCRIPTION
isn't initialised for non fsharp projects. This was causing XS to
crash if fsharp 3.0 wasn't installed.