### PR TITLE
Fix keyword tooltips

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -352,7 +352,7 @@ module SymbolTooltips =
             match KeywordList.keywordDescriptions.TryGetValue keyword with
             | true, description -> Full description
             | false, _ -> EmptyDoc
-        ToolTip(signatureline, summary, "")
+        signatureline, summary, ""
 
     let getSummaryFromSymbol (symbol:FSharpSymbol) =
         let xmlDoc, xmlDocSig =

--- a/MonoDevelop.FSharpBinding/Services/Parser.fs
+++ b/MonoDevelop.FSharpBinding/Services/Parser.fs
@@ -28,6 +28,12 @@ module Parsing =
         else
             Lexer.getSymbol lineStr 0 col lineStr SymbolLookupKind.Fuzzy [||] Lexer.singleLineQueryLexState
             |> Option.bind tryGetLexerSymbolIslands
+            
+    let findKeyword (col, lineStr) =
+        if lineStr = "" then None
+        else
+            Lexer.getSymbol lineStr 0 col lineStr SymbolLookupKind.Simple [||] Lexer.singleLineQueryLexState
+            |> Option.bind (fun t -> Some t.Text)
     
     /// find the identifier prior to a '(' or ',' once the method tip trigger '(' shows
     let findLongIdentsAtGetMethodsTrigger (col, lineStr) =


### PR DESCRIPTION
Nasty unsafe typing caused this, possibly during refactoring somewhere.
Also the new lexer filters out anything not an ident or operator