### PR TITLE
NullReferenceException is thrown if DefineConstants is not present in fsproj

### DIFF
--- a/MonoDevelop.FSharpBinding/Services/Parameters.fs
+++ b/MonoDevelop.FSharpBinding/Services/Parameters.fs
@@ -55,8 +55,11 @@ type FSharpCompilerParameters() =
         x.DefineConstants <- x.DefineConstants.Replace(";" + symbol, "")
 
   override x.GetDefineSymbols () =
-      x.DefineConstants.Split (';', ',', ' ', '\t')
-      |> Seq.where (String.IsNullOrWhiteSpace >> not)
+      if String.IsNullOrWhiteSpace x.DefineConstants then
+        Seq.empty
+      else
+        x.DefineConstants.Split (';', ',', ' ', '\t')
+        |> Seq.where (String.IsNullOrWhiteSpace >> not)
 
   override x.CreateCompilationOptions () =
       null //TODO


### PR DESCRIPTION
FSharpCompilerParameters.DefineConstants is initialized to null if no DefineConstants tag is present in fsproj, which leads to NullReferenceException while loading such project. Small fix -- checking value for null or whitespace -- solves the problem.