### PR TITLE
Let IDE handle the skin based highlighting selection

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
+++ b/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
@@ -59,11 +59,7 @@ type FSharpInteractivePad() as this =
             let textReceived = ses.TextReceived.Subscribe(fun t -> Runtime.RunInMainThread(fun () -> view.WriteOutput(t, promptReceived) ) |> ignore)
             let promptReady = ses.PromptReady.Subscribe(fun () -> Runtime.RunInMainThread(fun () -> promptReceived<- true; view.Prompt(true, Prompt.Normal) ) |> ignore)
             let colourSchemChanged =
-                PropertyService.PropertyChanged.Subscribe
-                    (fun _ (eventArgs:PropertyChangedEventArgs) ->
-                                      if eventArgs.Key = "ColorScheme-Dark" || eventArgs.Key = "ColorScheme" &&
-                                          eventArgs.OldValue <> eventArgs.NewValue then
-                                          this.UpdateColors ())
+                IdeApp.Preferences.ColorScheme.Changed.Subscribe (fun _ -> this.UpdateColors ())
             ses.Exited.Add(fun _ ->
                 textReceived.Dispose()
                 promptReady.Dispose()

--- a/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSyntaxMode.fs
@@ -387,11 +387,10 @@ type FSharpSyntaxMode(editor, context) =
     let tokenssymbolscolours = ref None
     let style = ref (getColourScheme())
     let colourSchemChanged =
-        PropertyService.PropertyChanged.Subscribe
-            (fun _ (eventArgs:PropertyChangedEventArgs) ->
-                              if eventArgs.Key = "ColorScheme" && eventArgs.OldValue <> eventArgs.NewValue then
-                                  let colourStyles = SyntaxModeService.GetColorStyle(IdeApp.Preferences.ColorScheme.Value)
-                                  style := colourStyles )
+        IdeApp.Preferences.ColorScheme.Changed.Subscribe
+            (fun _ (eventArgs:EventArgs) ->
+                              let colourStyles = SyntaxModeService.GetColorStyle(IdeApp.Preferences.ColorScheme.Value)
+                              style := colourStyles )
                                   
     override x.DocumentParsed() =
         if MonoDevelop.isDocumentVisible context.Name then

--- a/MonoDevelop.FSharpBinding/Services/FSharpConsoleView.fs
+++ b/MonoDevelop.FSharpBinding/Services/FSharpConsoleView.fs
@@ -184,10 +184,8 @@ type FSharpConsoleView() as x =
 
     member x.InitialiseEvents() =
         disposables.Add(
-            PropertyService.PropertyChanged.Subscribe
-              (fun _ (eventArgs:PropertyChangedEventArgs) ->
-                if eventArgs.Key = "ColorScheme-Dark" ||
-                   eventArgs.Key = "ColorScheme" && eventArgs.OldValue <> eventArgs.NewValue then
+            IdeApp.Preferences.ColorScheme.Changed.Subscribe
+              (fun _ (eventArgs:EventArgs) ->
                     updateColors()
                     x.ShowAll()))
 


### PR DESCRIPTION
To handle the syntax highlighting configuration changes
the Ide.Preferences.ColorScheme.Changed event should be used,
instead of listening to all property changes. The different
skin based settings are handled by the IDE automatically in
this case.