### PR TITLE
Add modifier keywords to completions

### DIFF
--- a/MonoDevelop.FSharp.Tests/CompletionTests.fs
+++ b/MonoDevelop.FSharp.Tests/CompletionTests.fs
@@ -26,7 +26,6 @@ type ``Completion Tests``() =
         editor.CaretOffset <- offset
         let ctx = new CodeCompletionContext()
         ctx.TriggerOffset <- offset
-
         let results =
             Completion.codeCompletionCommandImpl(getParseResults, editor, doc, ctx, false)
             |> Async.RunSynchronously
@@ -56,7 +55,7 @@ type ``Completion Tests``() =
     [<TestCase("let x =|")>]
     [<TestCase("let x, y|")>]
     [<TestCase("let x = \"System.|")>]
-    [<TestCase("let x = ``System.|");Ignore("Not implemented yet")>]
+    //[<TestCase("let x = ``System.|");Ignore("Not implemented yet")>]
     [<TestCase("member x|")>]
     [<TestCase("override x|")>]
     [<TestCase("1|")>]
@@ -92,7 +91,7 @@ type ``Completion Tests``() =
         let results = getCompletions @"o|"
         results |> should contain "open"
 
-    [<Test;Ignore("Not yet working")>]
+    [<Test>]
     member x.``Completes modifiers``() =
         let results = getCompletions @"let mut|"
         results |> should contain "mutable"

--- a/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
+++ b/MonoDevelop.FSharpBinding/Services/MDLanguageService.fs
@@ -159,6 +159,15 @@ module internal ServiceUtils =
              | _, _ -> "md-breakpoint"
 
 module internal KeywordList =
+    let modifiers = 
+        dict [
+            "abstract",  """Indicates a method that either has no implementation in the type in which it is declared or that is virtual and has a default implementation."""
+            "inline",  """Used to indicate a function that should be integrated directly into the caller's code."""
+            "mutable",  """Used to declare a variable, that is, a value that can be changed."""
+            "private",  """Restricts access to a member to code in the same type or module."""
+            "public",  """Allows access to a member from outside the type."""
+        ]
+
     let keywordDescriptions =
         dict [
             "abstract",  """Indicates a method that either has no implementation in the type in which it is declared or that is virtual and has a default implementation."""


### PR DESCRIPTION
To prevent the "No completions found" when typing an identifier
here -> `let myident|`
but allow completions
here -> `let mutab|`
but not here -> `let m|`