### PR TITLE
use background parse for completions when possible

### DIFF
--- a/MonoDevelop.FSharp.Tests/SemanticHighlighting.fs
+++ b/MonoDevelop.FSharp.Tests/SemanticHighlighting.fs
@@ -16,6 +16,7 @@ type SemanticHighlighting() =
         let doc = TestHelpers.createDoc fixedc "defined"
         let style = SyntaxModeService.GetColorStyle "Gruvbox"
         let tsc = SyntaxMode.tryGetTokensSymbolsAndColours doc
+
         let segments =
             doc.Editor.GetLines()
             |> Seq.map (fun line -> SyntaxMode.getColouredSegment tsc line.LineNumber line.Offset (doc.Editor.GetLineText line) style)

--- a/MonoDevelop.FSharp.Tests/TestHelpers.fs
+++ b/MonoDevelop.FSharp.Tests/TestHelpers.fs
@@ -47,7 +47,7 @@ module TestHelpers =
         let results = parseAndCheckFile source |> Async.RunSynchronously
         let options = ParseOptions(FileName = filename, Content = StringTextSource(source))
         let parsedDocument =
-            ParsedDocument.create options results [compilerDefines] |> Async.RunSynchronously
+            ParsedDocument.create options results [compilerDefines] Unparsed |> Async.RunSynchronously
 
         let doc = TextEditorFactory.CreateNewReadonlyDocument(StringTextSource(source), filename, "text/fsharp")
         let editor = MonoDevelop.Ide.Editor.TextEditorFactory.CreateNewEditor (doc)

--- a/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
+++ b/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
@@ -52,7 +52,7 @@ type FSharpInteractiveTextEditorOptions(options: MonoDevelop.Ide.Editor.DefaultS
 type FsiDocumentContext() =
     inherit DocumentContext()
     let name = "__FSI__.fsx"
-    let pd = new FSharpParsedDocument(name) :> ParsedDocument
+    let pd = new FSharpParsedDocument(name, None) :> ParsedDocument
     let project = Services.ProjectService.CreateDotNetProject ("F#")
 
     let mutable view:ICompletionWidget = null

--- a/MonoDevelop.FSharpBinding/FSharpParsedDocument.fs
+++ b/MonoDevelop.FSharpBinding/FSharpParsedDocument.fs
@@ -13,11 +13,13 @@ open System.Threading
 open MonoDevelop
 open Microsoft.FSharp.Compiler.SourceCodeServices
      
-type FSharpParsedDocument(fileName) =
+
+type FSharpParsedDocument(fileName, location: DocumentLocation option) =
     inherit DefaultParsedDocument(fileName,Flags = ParsedDocumentFlags.NonSerializable)
     member val Tokens : (FSharpTokenInfo list * int64) list option = None with get,set
     member val AllSymbolsKeyed = Dictionary<Range.pos, FSharpSymbolUse>() :> IDictionary<_,_> with get, set
-    
+    member x.ParsedLocation = location
+
 [<AutoOpen>]
 module DocumentContextExt =
     type DocumentContext with

--- a/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -65,6 +65,7 @@ type FSharpMemberCompletionData(name, icon, symbol:FSharpSymbolUse, overloads:FS
                 | (:? FSharpEntity as aa), (:? FSharpEntity as bb) ->
                     let comparisonResult =
                         let aaAllBases = ancestry aa
+
                         match (aaAllBases |> Seq.tryFind (fun a -> a.IsEffectivelySameAs bb)) with
                         | Some _ ->  -1
                         | _ ->
@@ -72,6 +73,7 @@ type FSharpMemberCompletionData(name, icon, symbol:FSharpSymbolUse, overloads:FS
                             match (bbAllBases |> Seq.tryFind (fun a -> a.IsEffectivelySameAs aa)) with
                             | Some _ ->  1
                             | _ -> aa.DisplayName.CompareTo(bb.DisplayName)
+
                     comparisonResult
                 | a, b -> a.DisplayName.CompareTo(b.DisplayName)
             | _ -> -1
@@ -92,6 +94,7 @@ module Completion =
 
     let (|InvalidToken|_|) context =
         let token = Tokens.getTokenAtPoint context.editor context.editor.DocumentContext context.triggerOffset
+
         if Tokens.isInvalidCompletionToken token then
             Some InvalidToken
         else
@@ -412,7 +415,6 @@ module Completion =
                     documentContext = documentContext
                     lineToCaret = lineToCaret
                     completionChar = completionChar
-                    ctrlSpace = ctrlSpace
                     } = context
 
                 let parsedDocument = documentContext.TryGetFSharpParsedDocument()
@@ -420,8 +422,8 @@ module Completion =
                 let! (typedParseResults: ParseAndCheckResults option) =
                     lock parseLock (fun() ->
                         async {
-                            match parsedDocument, ctrlSpace with
-                            | Some document, false  -> 
+                            match parsedDocument with
+                            | Some document -> 
                                 match document.ParsedLocation with
                                 | Some location ->
                                     if location.Line = context.line && location.Column > lineToCaret.LastIndexOf("->") then


### PR DESCRIPTION
Use background parse results, and only force a resync after entering a new lambda context