### PR TITLE
Fsi tooltips

### DIFF
--- a/MonoDevelop.FSharp.Tests/SyntaxHighlighting.fs
+++ b/MonoDevelop.FSharp.Tests/SyntaxHighlighting.fs
@@ -100,5 +100,9 @@ type SyntaxHighlighting() =
     [<TestCase(@"let rec computeSomeFunction §x§ =", "User Field Declaration")>]
     [<TestCase(@"Option.tryCast<MonoTextEditor§>(§fun e", "Punctuation(Brackets)")>]
     [<TestCase(@"let mutable session§ = §setupSession()", "Plain Text")>]
+    // tooltip highlighting
+    [<TestCase(@"static member §GetDefaultConfiguration§ :", "User Method Declaration")>]
+    [<TestCase(@"member §``Syntax Highlighting``§ :", "User Method Declaration")>]
+    [<TestCase(@"-> §^T§ :", "User Types")>]
     member x.``Syntax highlighting``(source, expectedStyle) =
         assertStyle (source, expectedStyle)

--- a/MonoDevelop.FSharp.Tests/SyntaxHighlighting.fs
+++ b/MonoDevelop.FSharp.Tests/SyntaxHighlighting.fs
@@ -100,9 +100,12 @@ type SyntaxHighlighting() =
     [<TestCase(@"let rec computeSomeFunction §x§ =", "User Field Declaration")>]
     [<TestCase(@"Option.tryCast<MonoTextEditor§>(§fun e", "Punctuation(Brackets)")>]
     [<TestCase(@"let mutable session§ = §setupSession()", "Plain Text")>]
-    // tooltip highlighting
+    member x.``Syntax highlighting``(source, expectedStyle) =
+        assertStyle (source, expectedStyle)
+
     [<TestCase(@"static member §GetDefaultConfiguration§ :", "User Method Declaration")>]
     [<TestCase(@"member §``Syntax Highlighting``§ :", "User Method Declaration")>]
     [<TestCase(@"-> §^T§ :", "User Types")>]
-    member x.``Syntax highlighting``(source, expectedStyle) =
+    [<TestCase(@"   §list§ :", "User Field Declaration")>]
+    member x.``Tooltip highlighting``(source, expectedStyle) =
         assertStyle (source, expectedStyle)

--- a/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
+++ b/MonoDevelop.FSharpBinding/FSharpInteractivePad.fs
@@ -227,6 +227,10 @@ type FSharpInteractivePad() =
         |> Option.iter(fun ses ->
             ses.SendCompletionRequest lineStr (column + 1))
 
+    member x.RequestTooltip symbol =
+        session 
+        |> Option.iter(fun ses -> ses.SendTooltipRequest symbol)
+
     member x.ProcessCommandHistoryUp () =
         if commandHistoryPast.Count > 0 then
             if commandHistoryFuture.Count = 0 then

--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -298,8 +298,8 @@ module internal Highlight =
     | Symbol | Brackets | Keyword | UserType | Number
 
     let getColourScheme () =
-        Highlighting.SyntaxModeService.GetColorStyle (IdeApp.Preferences.ColorScheme.Value)
-
+        //Highlighting.SyntaxModeService.GetColorStyle (IdeApp.Preferences.ColorScheme.Value)
+        Highlighting.SyntaxModeService.GetColorStyle ("Gruvbox")
     let getColourPart x = round(x * 255.0) |> int
 
     let argbToHex (c : Cairo.Color) =

--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -305,23 +305,24 @@ module internal Highlight =
     let argbToHex (c : Cairo.Color) =
         sprintf "#%02X%02X%02X" (getColourPart c.R) (getColourPart c.G) (getColourPart c.B)
 
-    let hl str (style: Highlighting.ChunkStyle) =
-        let color = getColourScheme().GetForeground (style) |> argbToHex
-        String.Format ("""<span foreground="{0}">{1}</span>""", color, str)
+    //let hl str (style: Highlighting.ChunkStyle) =
+    //    rethl
+    //    let color = getColourScheme().GetForeground (style) |> argbToHex
+    //    String.Format ("""<span foreground="{0}">{1}</span>""", color, str)
 
-    let asType t s =
-        let cs = getColourScheme ()
-        match t with
-        | Symbol -> hl s cs.KeywordOperators
-        | Brackets -> hl s cs.PunctuationForBrackets
-        | Keyword -> hl s cs.KeywordTypes
-        | UserType -> hl s cs.UserTypes
-        | Number -> hl s cs.Number
+    //let asType t s =
+    //    let cs = getColourScheme ()
+    //    match t with
+    //    | Symbol -> s cs.KeywordOperators
+    //    | Brackets -> s cs.PunctuationForBrackets
+    //    | Keyword -> s cs.KeywordTypes
+    //    | UserType -> s cs.UserTypes
+    //    | Number -> s cs.Number
 
-    let asSymbol = asType Symbol
-    let asKeyword = asType Keyword
-    let asBrackets = asType Brackets
-    let asUserType = asType UserType
+    //let asSymbol = asType Symbol
+    //let asKeyword = asType Keyword
+    //let asBrackets = asType Brackets
+    //let asUserType = asType UserType
     let asUnderline = sprintf "<u>%s</u>"
 
 
@@ -348,7 +349,7 @@ module SymbolTooltips =
         | false, false -> a + " " + b
 
     let getKeywordTooltip (keyword:string) =
-        let signatureline = asKeyword (escapeText keyword) ++ "(keyword)"
+        let signatureline = escapeText keyword ++ "(keyword)"
         let summary =
             match KeywordList.keywordDescriptions.TryGetValue keyword with
             | true, description -> Full description
@@ -386,9 +387,9 @@ module SymbolTooltips =
         if unionCase.UnionCaseFields.Count > 0 then
             let typeList =
                 unionCase.UnionCaseFields
-                |> Seq.map (fun unionField -> unionField.Name ++ asSymbol ":" ++ asUserType (escapeText (unionField.FieldType.Format displayContext)))
-                |> String.concat (asSymbol " * " )
-            unionCase.DisplayName ++ asKeyword "of" ++ typeList
+                |> Seq.map (fun unionField -> unionField.Name ++ ":" ++ (escapeText (unionField.FieldType.Format displayContext)))
+                |> String.concat " * "
+            unionCase.DisplayName ++ "of" ++ typeList
          else unionCase.DisplayName
 
     let formatGenericParameter displayContext (param:FSharpGenericParameter) =
@@ -414,7 +415,7 @@ module SymbolTooltips =
                 Some(s.Substring(4,s.Length - 4))
 
         let asGenericParamName (param: FSharpGenericParameter) =
-            asSymbol (if param.IsSolveAtCompileTime then "^" else "'") + param.Name
+            (if param.IsSolveAtCompileTime then "^" else "'") + param.Name
 
         let sb = new StringBuilder()
 
@@ -430,80 +431,80 @@ module SymbolTooltips =
                     | _, _ -> c.MemberName, false
 
                 seq {
-                    yield asSymbol " : ("
-                    if c.MemberIsStatic then yield asKeyword "static "
+                    yield " : ("
+                    if c.MemberIsStatic then yield "static "
 
-                    yield asKeyword "member "
-                    yield asUserType formattedMemberName
-                    yield asSymbol " : "
+                    yield "member "
+                    yield formattedMemberName
+                    yield " : "
 
                     if isProperty then
-                        yield asUserType (c.MemberReturnType.Format displayContext)
+                        yield (c.MemberReturnType.Format displayContext)
                     else
                         if c.MemberArgumentTypes.Count <= 1 then
-                            yield asUserType "unit"
+                            yield "unit"
                         else
                             yield asGenericParamName param
-                        yield asSymbol " -> "
-                        yield asUserType ((c.MemberReturnType.Format displayContext).TrimStart())
+                        yield " -> "
+                        yield ((c.MemberReturnType.Format displayContext).TrimStart())
 
-                    yield asBrackets ")"
+                    yield ")"
                 }
 
             let typeConstraint (tc: FSharpType) =
                 seq {
-                    yield asSymbol " :> "
-                    yield asUserType (tc.Format displayContext)
+                    yield " :> "
+                    yield (tc.Format displayContext)
                 }
 
             let constructorConstraint () =
                 seq {
-                    yield asSymbol " : "
-                    yield asBrackets "("
-                    yield asKeyword "new"
-                    yield asSymbol " : "
-                    yield asKeyword "unit"
-                    yield asSymbol " -> '"
+                    yield " : "
+                    yield "("
+                    yield "new"
+                    yield " : "
+                    yield "unit"
+                    yield " -> '"
                     yield param.DisplayName
-                    yield asBrackets ")"
+                    yield ")"
                 }
             let enumConstraint (ec: FSharpType) =
                 seq {
-                    yield asSymbol " : "
-                    yield asKeyword "enum"
-                    yield asBrackets (escapeText "<")
-                    yield asUserType (ec.Format displayContext)
-                    yield asBrackets (escapeText ">")
+                    yield " : "
+                    yield "enum"
+                    yield escapeText "<"
+                    yield ec.Format displayContext
+                    yield escapeText ">"
                 }
 
             let delegateConstraint (tc: FSharpGenericParameterDelegateConstraint) =
                 seq {
-                    yield asSymbol " : "
-                    yield asKeyword "delegate"
-                    yield asBrackets (escapeText "<")
-                    yield asUserType (tc.DelegateTupledArgumentType.Format displayContext)
-                    yield asSymbol ", "
-                    yield asUserType (tc.DelegateReturnType.Format displayContext)
-                    yield asBrackets (escapeText ">")
+                    yield " : "
+                    yield "delegate"
+                    yield escapeText "<"
+                    yield tc.DelegateTupledArgumentType.Format displayContext
+                    yield ", "
+                    yield tc.DelegateReturnType.Format displayContext
+                    yield escapeText ">"
                 }
 
             let symbols =
                 match constrainedBy with
                 | _ when constrainedBy.IsCoercesToConstraint -> typeConstraint constrainedBy.CoercesToTarget
                 | _ when constrainedBy.IsMemberConstraint -> memberConstraint constrainedBy.MemberConstraintData
-                | _ when constrainedBy.IsSupportsNullConstraint -> seq { yield asSymbol " : "; yield asKeyword "null" }
+                | _ when constrainedBy.IsSupportsNullConstraint -> seq { yield " : "; yield "null" }
                 | _ when constrainedBy.IsRequiresDefaultConstructorConstraint -> constructorConstraint()
-                | _ when constrainedBy.IsReferenceTypeConstraint -> seq { yield asSymbol " : "; yield asKeyword "not struct" }
+                | _ when constrainedBy.IsReferenceTypeConstraint -> seq { yield " : "; yield "not struct" }
                 | _ when constrainedBy.IsEnumConstraint -> enumConstraint constrainedBy.EnumConstraintTarget
-                | _ when constrainedBy.IsComparisonConstraint -> seq { yield asSymbol " : "; yield asKeyword "comparison" }
-                | _ when constrainedBy.IsEqualityConstraint -> seq { yield asSymbol " : "; yield asKeyword "equality" }
+                | _ when constrainedBy.IsComparisonConstraint -> seq { yield " : "; yield "comparison" }
+                | _ when constrainedBy.IsEqualityConstraint -> seq { yield " : "; yield "equality" }
                 | _ when constrainedBy.IsDelegateConstraint -> delegateConstraint constrainedBy.DelegateConstraintData
-                | _ when constrainedBy.IsUnmanagedConstraint -> seq { yield asSymbol " : "; yield asKeyword "unmanaged"}
-                | _ when constrainedBy.IsNonNullableValueTypeConstraint -> seq { yield asSymbol " : "; yield asKeyword "struct" }
+                | _ when constrainedBy.IsUnmanagedConstraint -> seq { yield " : "; yield "unmanaged"}
+                | _ when constrainedBy.IsNonNullableValueTypeConstraint -> seq { yield " : "; yield "struct" }
                 | _ -> Seq.empty
 
             seq {
-                yield asKeyword " when "
+                yield " when "
                 yield asGenericParamName param
                 yield! symbols
             }
@@ -537,8 +538,8 @@ module SymbolTooltips =
         let modifiers =
             let accessibility =
                 match func.Accessibility with
-                | a when a.IsInternal -> asKeyword "internal"
-                | a when a.IsPrivate -> asKeyword "private"
+                | a when a.IsInternal -> "internal"
+                | a when a.IsPrivate -> "private"
                 | _ -> ""
 
             let modifier =
@@ -569,12 +570,12 @@ module SymbolTooltips =
         let retType =
             //This try block will be removed when FCS updates
             try
-                asUserType (escapeText(func.ReturnParameter.Type.Format displayContext))
+                escapeText(func.ReturnParameter.Type.Format displayContext)
             with _ex ->
                 try
                     if func.FullType.GenericArguments.Count > 0 then
                         let lastArg = func.FullType.GenericArguments |> Seq.last
-                        asUserType (escapeText(lastArg.Format displayContext))
+                        escapeText(lastArg.Format displayContext)
                     else "Unknown"
                 with _ -> "Unknown"
 
@@ -592,27 +593,27 @@ module SymbolTooltips =
             match format.Highlight with
             | Some paramName when paramName = name ->
                 match padding - name.Length with
-                | i when i > 0 -> indent + asUnderline name + String.replicate i " " + asSymbol ":"
-                | _ -> indent + asUnderline name + asSymbol ":"
-            | _ -> indent + name.PadRight padding + asSymbol ":"
+                | i when i > 0 -> indent + asUnderline name + String.replicate i " " + ":"
+                | _ -> indent + asUnderline name + ":"
+            | _ -> indent + name.PadRight padding + ":"
 
         let isDelegate =
             match func.EnclosingEntitySafe with
             | Some ent -> ent.IsDelegate
             | _ ->
-                LoggingService.LogWarning(sprintf "getFuncSignatureWithFormat: No enclosing entity found for: %s" func.DisplayName)
+                LoggingService.logWarning "getFuncSignatureWithFormat: No enclosing entity found for: %s" func.DisplayName
                 false
 
         match argInfos with
         | [] ->
             //When does this occur, val type within  module?
             if isDelegate then retType
-            else asKeyword modifiers ++ functionName ++ asSymbol ":" ++ retType
+            else modifiers ++ functionName ++ ":" ++ retType
 
         | [[]] ->
             //A ctor with () parameters seems to be a list with an empty list
             if isDelegate then retType
-            else asKeyword modifiers ++ functionName ++ asSymbol "() :" ++ retType
+            else modifiers ++ functionName ++ "() :" ++ retType
         | many ->
               let allParamsLengths =
                   many |> List.map (List.map (fun p -> (p.Type.Format displayContext).Length) >> List.sum)
@@ -625,23 +626,23 @@ module SymbolTooltips =
                   List.zip many allParamsLengths
                   |> List.map(fun (paramTypes, length) ->
                                   paramTypes
-                                  |> List.map(fun p -> formatName indent padLength p ++ asUserType (parameterTypeWithPadding p length))
-                                  |> String.concat (asSymbol " *" ++ "\n"))
-                  |> String.concat (asSymbol "->" + "\n")
+                                  |> List.map(fun p -> formatName indent padLength p ++ (parameterTypeWithPadding p length))
+                                  |> String.concat (" *" ++ "\n"))
+                  |> String.concat ("->\n")
 
               let typeArguments =
-                  allParams +  "\n" + indent + (String.replicate (max (padLength-1) 0) " ") +  asSymbol "->" ++ retType
+                  allParams +  "\n" + indent + (String.replicate (max (padLength-1) 0) " ") + "->" ++ retType
 
               if isDelegate then typeArguments
-              else asKeyword modifiers ++ functionName ++ asSymbol ":" + "\n" + typeArguments
+              else modifiers ++ functionName ++ ":" + "\n" + typeArguments
 
     let getFuncSignature f c = getFuncSignatureWithFormat f c FormatOptions.Default
 
     let getEntitySignature displayContext (fse: FSharpEntity) =
         let modifier =
             match fse.Accessibility with
-            | a when a.IsInternal -> asKeyword "internal "
-            | a when a.IsPrivate -> asKeyword "private "
+            | a when a.IsInternal -> "internal "
+            | a when a.IsPrivate -> "private "
             | _ -> ""
 
         let typeName =
@@ -653,40 +654,40 @@ module SymbolTooltips =
             | _                         -> "type"
 
         let enumtip () =
-            asSymbol " =" + "\n" +
-            asSymbol "|" ++
+            " =\n" +
+            "|" ++
             (fse.FSharpFields
             |> Seq.filter (fun f -> not f.IsCompilerGenerated)
             |> Seq.map (fun field -> match field.LiteralValue with
-                                     | Some lv -> field.Name + asSymbol " = " + asType Number (string lv)
+                                     | Some lv -> field.Name + " = " + (string lv)
                                      | None -> field.Name )
-            |> String.concat ("\n" + asSymbol "| " ) )
+            |> String.concat ("\n" + "| " ) )
 
         let uniontip () =
-            asSymbol " =" + "\n" +
-            asSymbol "|" ++ (fse.UnionCases
+            " =" + "\n" +
+            "|" ++ (fse.UnionCases
                                   |> Seq.map (getUnioncaseSignature displayContext)
-                                  |> String.concat ("\n" + asSymbol "| " ) )
+                                  |> String.concat ("\n" + "| " ) )
 
         let delegateTip () =
             let invoker =
                 fse.MembersFunctionsAndValues |> Seq.find (fun f -> f.DisplayName = "Invoke")
             let invokerSig = getFuncSignatureWithFormat displayContext invoker {Indent=6;Highlight=None}
-            asSymbol " =" + "\n" +
-            "   " + asKeyword "delegate" + " of\n" + invokerSig
+            " =" + "\n" +
+            "   " + "delegate" + " of\n" + invokerSig
 
         let typeDisplay =
             let name =
                 if fse.GenericParameters.Count > 0 then
                     let p = fse.GenericParameters |> Seq.map (formatGenericParameter displayContext) |> String.concat ","
-                    asUserType fse.DisplayName + asBrackets (escapeText "<") + asUserType p + asBrackets (escapeText ">")
-                else asUserType fse.DisplayName
+                    fse.DisplayName + (escapeText "<") + p + (escapeText ">")
+                else fse.DisplayName
 
-            let basicName = modifier + asKeyword typeName ++ name
+            let basicName = modifier + typeName ++ name
 
             if fse.IsFSharpAbbreviation then
                 let unannotatedType = fse.UnAnnotate()
-                basicName ++ asBrackets "=" ++ asKeyword (escapeText unannotatedType.DisplayName)
+                basicName ++ "=" ++ (escapeText unannotatedType.DisplayName)
             else
                 basicName
 
@@ -701,25 +702,25 @@ module SymbolTooltips =
         else typeDisplay + fullName
 
     let getValSignature displayContext (v:FSharpMemberOrFunctionOrValue) =
-        let retType = asUserType (escapeText(v.FullType.Format(displayContext)))
+        let retType = (escapeText(v.FullType.Format(displayContext)))
         let prefix =
-            if v.IsMutable then asKeyword "val" ++ asKeyword "mutable"
-            else asKeyword "val"
+            if v.IsMutable then "val" ++ "mutable"
+            else "val"
         let name =
             if v.DisplayName.StartsWith "( "
             then PrettyNaming.QuoteIdentifierIfNeeded v.LogicalName
             else v.DisplayName
-        prefix ++ name ++ asSymbol ":" ++ retType
+        prefix ++ name ++ ":" ++ retType
 
     let getFieldSignature displayContext (field: FSharpField) =
-        let retType = asUserType (escapeText(field.FieldType.Format displayContext))
+        let retType = (escapeText(field.FieldType.Format displayContext))
         match field.LiteralValue with
-        | Some lv -> field.DisplayName ++ asSymbol ":" ++ retType ++ asSymbol "=" ++ asType Number (string lv)
+        | Some lv -> field.DisplayName ++ ":" ++ retType ++ "=" ++ (string lv)
         | None ->
             let prefix =
-                if field.IsMutable then asKeyword "val" ++ asKeyword "mutable"
-                else asKeyword "val"
-            prefix ++ field.DisplayName ++ asSymbol ":" ++ retType
+                if field.IsMutable then "val" ++ "mutable"
+                else "val"
+            prefix ++ field.DisplayName ++ ":" ++ retType
 
     let getAPCaseSignature displayContext (apc:FSharpActivePatternCase) =
       let findVal =
@@ -838,10 +839,10 @@ module SymbolTooltips =
             None
 
     let getTooltipFromParameter (p:FSharpParameter) context =
-      let typ = asUserType (escapeText(p.Type.Format(context)))
+      let typ = (escapeText(p.Type.Format(context)))
       let signature =
           match p.Name with
-          | Some name -> name ++ asSymbol ":" ++ typ
+          | Some name -> name ++ ":" ++ typ
           | None -> typ
 
       signature, getSummaryFromSymbol p

--- a/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
+++ b/MonoDevelop.FSharpBinding/FSharpSymbolHelper.fs
@@ -676,15 +676,12 @@ module SymbolTooltips =
             else
                 basicName
 
-        let fullName =
-            match fse.TryGetFullNameWithUnderScoreTypes() with
-            | Some fullname -> "\n\n<small>Full name: " + fullname + "</small>"
-            | None -> "\n\n<small>Full name: " + fse.QualifiedName + "</small>"
+        
 
-        if fse.IsFSharpUnion then typeDisplay + uniontip () + fullName
-        elif fse.IsEnum then typeDisplay + enumtip () + fullName
-        elif fse.IsDelegate then typeDisplay + delegateTip () + fullName
-        else typeDisplay + fullName
+        if fse.IsFSharpUnion then typeDisplay + uniontip ()
+        elif fse.IsEnum then typeDisplay + enumtip ()
+        elif fse.IsDelegate then typeDisplay + delegateTip ()
+        else typeDisplay
 
     let getValSignature displayContext (v:FSharpMemberOrFunctionOrValue) =
         let retType = v.FullType.Format displayContext
@@ -732,7 +729,12 @@ module SymbolTooltips =
       
         | Entity c ->
             let ns = c.Namespace |> Option.getOrElse (fun () -> c.AccessPath)
-            sprintf "<small>Namespace:\t%s</small>%s<small>Assembly:\t%s</small>" ns Environment.NewLine c.Assembly.SimpleName
+            let fullName =
+                match c.TryGetFullNameWithUnderScoreTypes() with
+                | Some fullname -> "<small>Full name: " + fullname + "</small>"
+                | None -> "<small>Full name: " + c.QualifiedName + "</small>"
+
+            sprintf "%s%s<small>Namespace:\t%s</small>%s<small>Assembly:\t%s</small>" fullName Environment.NewLine ns Environment.NewLine c.Assembly.SimpleName
       
         | Field f ->
             let parent = f.DeclaringEntity.UnAnnotate().DisplayName

--- a/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTextEditorCompletion.fs
@@ -224,12 +224,12 @@ module Completion =
                         if ap.Group.Names.Count > 1 then
                             ap.Group.EnclosingEntity
                             |> Option.map (fun enclosing -> let un = enclosing.UnAnnotate()
-                                                            SymbolTooltips.escapeText un.DisplayName, un)
+                                                            un.DisplayName, un)
                         else None
                     | UnionCase uc ->
                         if uc.UnionCaseFields.Count > 1 then
                             let ent = uc.ReturnType.TypeDefinition.UnAnnotate()
-                            Some(SymbolTooltips.escapeText ent.DisplayName, ent)
+                            Some(ent.DisplayName, ent)
                         else None
                     | Function f ->
                         if f.IsExtensionMember then

--- a/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTooltipProvider.fs
@@ -69,9 +69,16 @@ type FSharpTooltipProvider() =
                         let! tip = SymbolTooltips.getTooltipFromSymbolUse symbol
                                    |> Choice.ofOptionWith (sprintf "TooltipProvider: TootipText not returned\n   %s\n   %s" lineStr (String.replicate col "-" + "^"))
                       
+                        let highlightedTip = 
+                            match tip with
+                            | (signature, xmldoc, footer) ->
+                                syntaxHighlight signature, xmldoc, footer
+                            | _ -> tip
+
                         //get the TextSegment the the symbols range occupies
                         let textSeg = Symbols.getTextSegment editor symbol col lineStr
-                        let tooltipItem = TooltipItem(tip, textSeg)
+
+                        let tooltipItem = TooltipItem(highlightedTip, textSeg)
                         return tooltipItem
 
                     with

--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -205,10 +205,6 @@
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <ProjectReference Include="..\MonoDevelop.FSharpi.Service\MonoDevelop.FSharpInteractive.Service.fsproj">
-      <Project>{20D6EC2C-B62E-49D1-B685-90D8967A5B5D}</Project>
-      <Name>MonoDevelop.FSharpInteractive.Service</Name>
-    </ProjectReference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/MonoDevelop.FSharpBinding/ProjectSearchCategory.fs
+++ b/MonoDevelop.FSharpBinding/ProjectSearchCategory.fs
@@ -175,7 +175,9 @@ type SymbolSearchResult(match', matchedString, rank, symbol:FSharpSymbolUse) =
         | Val _ -> getImage "md-fs-field" //NOTE: Maybe make this a normal field icon?
         | _ -> getImage Stock.Event.Name
 
-    override x.GetTooltipInformation(token) = Async.StartAsTask(SymbolTooltips.getTooltipInformation symbol, cancellationToken = token)
+    override x.GetTooltipInformation(_token) = 
+        SymbolTooltips.getTooltipInformation symbol true |> Async.StartAsTask
+        
     override x.Offset = fst (offsetAndLength.Force())
     override x.Length = snd (offsetAndLength.Force())
 

--- a/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
+++ b/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
@@ -68,7 +68,6 @@ type InteractiveSession() =
     let completionsReceivedEvent = new Event<CompletionData list>()
     let tooltipReceivedEvent = new Event<TooltipInformation>()
     do
-        sendCommand ("colorscheme " + IdeApp.Preferences.ColorScheme.Value)
         fsiProcess.OutputDataReceived
           |> Event.filter (fun de -> de.Data <> null)
           |> Event.add (fun de ->

--- a/MonoDevelop.FSharpBinding/Services/TooltipHelpers.fs
+++ b/MonoDevelop.FSharpBinding/Services/TooltipHelpers.fs
@@ -156,15 +156,14 @@ module TooltipXmlDoc =
     
     ///check helpxml exist
     let tryGetDoc key =
-      let helpTree = MonoDevelop.Projects.HelpService.HelpTree
-      if helpTree = null then None else
-      try
-
-          let helpxml = helpTree.GetHelpXml(key)
-          if helpxml = null then None else Some(helpxml)
-      with ex ->
-          LoggingService.LogError ("GetHelpXml failed for key {0}", key, ex)
-          None
+        try
+            let helpTree = MonoDevelop.Projects.HelpService.HelpTree
+            if helpTree = null then None else
+            let helpxml = helpTree.GetHelpXml(key)
+            if helpxml = null then None else Some(helpxml)
+        with ex ->
+            LoggingService.LogError ("GetHelpXml failed for key {0}", key, ex)
+            None
     
     let (|MemberName|_|) (name:string) =
         let dotRight = name.LastIndexOf '.'

--- a/MonoDevelop.FSharpBinding/Services/TooltipHelpers.fs
+++ b/MonoDevelop.FSharpBinding/Services/TooltipHelpers.fs
@@ -7,6 +7,8 @@ open System.Collections.Generic
 open System.Linq
 open System.Xml
 open System.Xml.Linq
+open Mono.TextEditor
+open Mono.TextEditor.Highlighting
 open MonoDevelop.Core
 open ExtCore.Control
 

--- a/MonoDevelop.FSharpi.Service/Completions.fs
+++ b/MonoDevelop.FSharpi.Service/Completions.fs
@@ -99,6 +99,11 @@ module Completion =
     let getCompletionTooltip filter =
         async {
             let symbol = 
-                symbolList |> List.find (fun sym -> sym.Symbol.DisplayName = filter)
-            return! SymbolTooltips.getTooltipInformation symbol
+                symbolList |> List.tryFind (fun sym -> sym.Symbol.DisplayName = filter)
+            
+            match symbol with
+            | Some sym ->
+                return! SymbolTooltips.getTooltipInformation symbol.Value false
+            | None -> 
+                return MonoDevelop.Ide.CodeCompletion.TooltipInformation()
         }

--- a/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
+++ b/MonoDevelop.FSharpi.Service/MonoDevelop.FSharpInteractive.Service.fsproj
@@ -45,6 +45,19 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
     <Reference Include="FSharp.Compiler.Interactive.Settings" />
+    <Reference Include="MonoDevelop.Ide">
+      <HintPath>..\..\..\build\bin\MonoDevelop.Ide.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.TextEditor">
+      <HintPath>..\..\..\build\bin\Mono.TextEditor.dll</HintPath>
+    </Reference>
+    <Reference Include="Mono.Addins">
+      <HintPath>..\..\..\build\bin\Mono.Addins.dll</HintPath>
+    </Reference>
+    <Reference Include="gtk-sharp, Version=2.12.0.0, Culture=neutral, PublicKeyToken=35e10195dab3c99f" />
+    <Reference Include="MonoDevelop.Core">
+      <HintPath>..\..\..\build\bin\MonoDevelop.Core.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AssemblyInfo.fs" />
@@ -57,6 +70,12 @@
   <ItemGroup>
     <None Include="paket.references" />
     <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\MonoDevelop.FSharpBinding\MonoDevelop.FSharp.fsproj">
+      <Project>{4C10F8F9-3816-4647-BA6E-85F5DE39883A}</Project>
+      <Name>MonoDevelop.FSharp</Name>
+    </ProjectReference>
   </ItemGroup>
   <Import Project="$(FSharpTargetsPath)" />
   <Import Project="..\.paket\paket.targets" />

--- a/MonoDevelop.FSharpi.Service/Program.fs
+++ b/MonoDevelop.FSharpi.Service/Program.fs
@@ -2,6 +2,7 @@
 open System
 open System.IO
 open System.Text
+open MonoDevelop.Ide
 open Newtonsoft.Json
 open Microsoft.FSharp.Compiler.SourceCodeServices
 open Microsoft.FSharp.Compiler.Interactive.Shell
@@ -28,6 +29,17 @@ module CompletionServer =
             else
                 None
 
+        let (|Tooltip|_|) (command: string) =
+            if command.StartsWith("tooltip ") then
+                Some(command.[8..])
+            else
+                None
+
+        let (|ColorScheme|_|) (command: string) =
+            if command.StartsWith("colorscheme ") then
+                Some(command.[12..])
+            else
+                None
         let (|Completion|_|) (command: string) =
             if command.StartsWith("completion ") then
                 let input = command.[11..]
@@ -53,11 +65,11 @@ module CompletionServer =
             let parseInput() =
                 async {
                     let! command = inStream.ReadLineAsync() |> Async.AwaitTask
+
                     match command with
                     | Input input ->
                         if input.EndsWith(";;") then
                             try
-                                //do! writeLine (currentInput + input)
                                 let result, warnings = fsiSession.EvalInteractionNonThrowing (currentInput + input)
                                 match result with
                                 | Choice1Of2 () -> ()
@@ -72,12 +84,20 @@ module CompletionServer =
                             return ""
                         else
                             return currentInput + "\n" + input
+                    | ColorScheme colorScheme ->
+                        //IdeApp.Preferences.ColorScheme.Value <- colorScheme
+                        return currentInput
+                    | Tooltip filter ->
+                        let! tooltip = Completion.getCompletionTooltip filter
+                        let json = JsonConvert.SerializeObject tooltip
+                        do! Console.Error.WriteLineAsync ("tooltip " + json) |> Async.AwaitTask
+                        return currentInput
                     | Completion context ->
                         let col, lineStr = context
                         let! results = Completion.getCompletions(fsiSession, lineStr, col)
 
                         let json = JsonConvert.SerializeObject results
-                        do! Console.Error.WriteLineAsync json |> Async.AwaitTask
+                        do! Console.Error.WriteLineAsync ("completion " + json) |> Async.AwaitTask
                         return currentInput
                     | _ -> do! writeLine (sprintf "Could not parse command - %s" command)
                            return currentInput

--- a/MonoDevelop.FSharpi.Service/Program.fs
+++ b/MonoDevelop.FSharpi.Service/Program.fs
@@ -21,7 +21,7 @@ module CompletionServer =
 
         let serializer = JsonSerializer.Create()
         let fsiConfig = FsiEvaluationSession.GetDefaultConfiguration(Settings.fsi, true)
-        let fsiSession = FsiEvaluationSession.Create(fsiConfig, argv, inStream, outStream, outStream)
+        let fsiSession = FsiEvaluationSession.Create(fsiConfig, argv, inStream, outStream, outStream, true)
 
         let (|Input|_|) (command: string) =
             if command.StartsWith("input ") then
@@ -35,11 +35,6 @@ module CompletionServer =
             else
                 None
 
-        let (|ColorScheme|_|) (command: string) =
-            if command.StartsWith("colorscheme ") then
-                Some(command.[12..])
-            else
-                None
         let (|Completion|_|) (command: string) =
             if command.StartsWith("completion ") then
                 let input = command.[11..]
@@ -84,9 +79,6 @@ module CompletionServer =
                             return ""
                         else
                             return currentInput + "\n" + input
-                    | ColorScheme colorScheme ->
-                        //IdeApp.Preferences.ColorScheme.Value <- colorScheme
-                        return currentInput
                     | Tooltip filter ->
                         let! tooltip = Completion.getCompletionTooltip filter
                         let json = JsonConvert.SerializeObject tooltip


### PR DESCRIPTION
Adds tooltips to completions in F# interactive.

Also, uses syntax highlighting to colour the tooltips everywhere, so removed lots of formatting code from FSharpSymbolHelper.fs. This file could be cleaned up a lot further now I think too.