### PR TITLE
Fsi margin

### DIFF
--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -205,6 +205,9 @@
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
+    <Reference Include="MonoDevelop.SourceEditor">
+      <HintPath>..\..\..\build\AddIns\DisplayBindings\SourceEditor\MonoDevelop.SourceEditor.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
+++ b/MonoDevelop.FSharpBinding/MonoDevelop.FSharp.fsproj
@@ -205,9 +205,6 @@
       <HintPath>..\..\..\build\bin\Microsoft.CodeAnalysis.Workspaces.dll</HintPath>
       <Private>False</Private>
     </Reference>
-    <Reference Include="MonoDevelop.SourceEditor">
-      <HintPath>..\..\..\build\AddIns\DisplayBindings\SourceEditor\MonoDevelop.SourceEditor.dll</HintPath>
-    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
+++ b/MonoDevelop.FSharpBinding/Services/InteractiveSession.fs
@@ -109,19 +109,11 @@ type InteractiveSession() =
     member x.PromptReady = promptReady.Publish
 
     member x.Kill() =
-        if not fsiProcess.HasExited then
-            sendCommand "#q"
-            for i in 0 .. 10 do
-                if not fsiProcess.HasExited then
-                    LoggingService.logDebug "Interactive: waiting for process exit after #q... %d" (i*200)
-                    fsiProcess.WaitForExit(200) |> ignore
-
-        if not fsiProcess.HasExited then
-            fsiProcess.Kill()
-            for i in 0 .. 10 do
-                if not fsiProcess.HasExited then
-                    LoggingService.logDebug "Interactive: waiting for process exit after kill... %d" (i*200)
-                    fsiProcess.WaitForExit(200) |> ignore
+        fsiProcess.Kill()
+        for i in 0 .. 10 do
+            if not fsiProcess.HasExited then
+                LoggingService.logDebug "Interactive: waiting for process exit after kill... %d" (i*200)
+                fsiProcess.WaitForExit(200) |> ignore
 
         if not fsiProcess.HasExited then
             LoggingService.logWarning "Interactive: failed to get process exit after kill"


### PR DESCRIPTION
Implements fsi prompt using the text editor margin so removes a lot of hacks dealing with the old fake prompt.

Also, fixed command history and now the kill and restart commands force quit immediately.