### PR TITLE
Another potential NullReferenceException

### DIFF
--- a/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -258,7 +258,7 @@ module CompilerArguments =
                 |> Seq.filter(fun f -> f.FilePath.Extension = ".fs")
                 |> Seq.map(fun f -> f.Name)
 
-    let defines = fsconfig.DefineConstants.Split([| ';'; ','; ' ' |], StringSplitOptions.RemoveEmptyEntries)
+    let defines = fsconfig.GetDefineSymbols() // fsconfig.DefineConstants.Split([| ';'; ','; ' ' |], StringSplitOptions.RemoveEmptyEntries)
     [  
        yield "--simpleresolution"
        yield "--noframework"


### PR DESCRIPTION
Using fsconfig.DefineConstants.Split(...) generates NullReferenceException if no such tag is present in project file. This have already been fixed in fsconfig.GetDefineSymbols, yet DefineConstants is accessed directly in CompilerArguments.fs.

Using GetDefineSymblos instead removes code duplication (define symbol splitting) and eliminates possibility of NullReferenceException, which caused tooltip initialization to fail.