### PR TITLE
filter completions by first character

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpTokens.fs
+++ b/MonoDevelop.FSharpBinding/FSharpTokens.fs
@@ -34,9 +34,8 @@ module Tokens =
 
     let isInvalidCompletionToken (token:FSharpTokenInfo option) =
         match token with 
-        | Some token -> Lexer.isNonTipToken token//token.CharClass <> FSharpTokenCharKind.WhiteSpace
-                        //&& Lexer.isNonTipToken token
-        | None -> true
+        | Some token -> Lexer.isNonTipToken token
+        | None -> false
                 
     let tryGetTokens source defines fileName =
         try


### PR DESCRIPTION
Filter by first character to reduce the risk of completing the wrong value.

Also fixes ctrl-space when at the first character of a line.