### PR TITLE
Fix references

### DIFF
--- a/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
+++ b/MonoDevelop.FSharpBinding/FSharpPathExtension.fs
@@ -4,7 +4,6 @@ open System
 open System.Collections.Generic
 open System.Linq
 open System.Diagnostics
-open MonoDevelop
 open MonoDevelop.Core
 open MonoDevelop.Projects
 open MonoDevelop.Components
@@ -52,18 +51,13 @@ type FSharpPathExtension() as x =
         |> Option.bind (Option.condition ownerProjects.Contains)
         |> Option.iter x.DocumentContext.AttachToProject)
 
-    let getSolutions () =
-        ownerProjects
-        |> Seq.map (fun p -> p.ParentSolution |> Option.ofObj)
-        |> Seq.distinct
-
     let untrackStartupProjectChanges () =
-        for sol in getSolutions() do
-            sol |> Option.iter(fun sol -> sol.StartupItemChanged.RemoveHandler handleStartupProjectChanged)
+        for sol in (ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct) do
+            sol.StartupItemChanged.RemoveHandler handleStartupProjectChanged
 
     let trackStartupProjectChanges() =
-        for sol in getSolutions() do
-            sol |> Option.iter(fun sol -> sol.StartupItemChanged.RemoveHandler handleStartupProjectChanged)
+        for sol in (ownerProjects |> Seq.map (fun p -> p.ParentSolution) |> Seq.distinct) do
+            sol.StartupItemChanged.AddHandler handleStartupProjectChanged
 
     let setOwnerProjects (projects) =
         untrackStartupProjectChanges ()
@@ -191,7 +185,11 @@ type FSharpPathExtension() as x =
         | context when context.Name <> x.DocumentContext.Name -> ()
         | _ ->
       
-        let ast = x.DocumentContext.TryGetAst()
+        let ast =
+            maybe { let! context = x.DocumentContext |> Option.ofNull
+                    let! parsedDocument = context.ParsedDocument |> Option.ofNull
+                    let! ast = parsedDocument.Ast |> Option.tryCast<ParseAndCheckResults>
+                    return ast }
       
         let caretLocation = x.Editor.CaretLocation
         ast |> Option.iter (fun ast ->

--- a/MonoDevelop.FSharpBinding/FSharpProject.fs
+++ b/MonoDevelop.FSharpBinding/FSharpProject.fs
@@ -44,8 +44,9 @@ type FSharpProject() as self =
     let invalidateProjectFile() =
         try
             if File.Exists (self.FileName.ToString()) then
-                let options = languageService.GetProjectCheckerOptions (self.FileName.ToString())
+                let options = languageService.GetProjectCheckerOptions(self.FileName.ToString(), [("Configuration", IdeApp.Workspace.ActiveConfigurationId)])
                 languageService.InvalidateConfiguration(options)
+                languageService.ClearProjectInfoCache()
         with ex -> LoggingService.LogError ("Could not invalidate configuration", ex)
 
     let invalidateFiles (args:#ProjectFileEventInfo seq) =

--- a/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
+++ b/MonoDevelop.FSharpBinding/Services/CompilerArguments.fs
@@ -58,11 +58,11 @@ module CompilerArguments =
 
       let getAssemblyLocations (reference:ProjectReference) =
           let tryGetFromHintPath() =
-              if reference.HintPath.IsNotNull then 
+              if reference.HintPath.IsNotNull then
                   let path = reference.HintPath.FullPath |> string
                   let path = path.Replace("/Library/Frameworks/Mono.framework/External",
                                           "/Library/Frameworks/Mono.framework/Versions/Current/lib/mono")
-                  if File.Exists path then 
+                  if File.Exists path then
                       [path]
                   else
                       // try and resolve from GAC
@@ -76,9 +76,9 @@ module CompilerArguments =
           | ReferenceType.Package ->
               if isNull reference.Package then
                   tryGetFromHintPath()
-              else 
+              else
                   if reference.Include <> "System" then
-                      let assembly = 
+                      let assembly =
                               reference.Package.Assemblies
                               |> Seq.find (fun a -> a.Name = reference.Include)
                       [assembly.Location]
@@ -87,7 +87,7 @@ module CompilerArguments =
                       |> Seq.map (fun a -> a.Location)
                       |> List.ofSeq
 
-          | ReferenceType.Project -> 
+          | ReferenceType.Project ->
               let referencedProject = reference.Project :?> DotNetProject
               let reference =
                   referencedProject.GetReferencedAssemblyProjects (getCurrentConfigurationOrDefault referencedProject)
@@ -187,11 +187,11 @@ module CompilerArguments =
                let hasTargetFrameworkProfile() =
                    try
                        assembly.GetCustomAttributes(true)
-                       |> Seq.tryFind (fun a -> 
+                       |> Seq.tryFind (fun a ->
                               match a with
-                              | :? TargetFrameworkAttribute as attr -> 
+                              | :? TargetFrameworkAttribute as attr ->
                                    let fn = new FrameworkName(attr.FrameworkName)
-                                   not (fn.Profile = "")             
+                                   not (fn.Profile = "")
                               | _ -> false)
                        |> Option.isSome
                    with
@@ -201,8 +201,8 @@ module CompilerArguments =
                referencesSystemRuntime() || hasTargetFrameworkProfile()
            with
            | _e -> false
-                        
-       let needsFacades () = 
+
+       let needsFacades () =
            let referencedAssemblies = project.GetReferencedAssemblyProjects configSelector
 
            match referencedAssemblies |> Seq.tryFind Project.isPortable with
@@ -297,11 +297,11 @@ module CompilerArguments =
                 |> Seq.map(fun f -> f.Name)
 
     let defines = fsconfig.GetDefineSymbols()
-    [  
+    [
        yield "--simpleresolution"
        yield "--noframework"
        yield "--out:" + project.GetOutputFileName(configSelector).ToString()
-       if Project.isPortable project then 
+       if Project.isPortable project then
            yield "--targetprofile:netcore"
        yield "--platform:anycpu" //?
        yield "--fullpaths"
@@ -311,14 +311,14 @@ module CompilerArguments =
        yield if fsconfig.Optimize then "--optimize+" else "--optimize-"
        yield if fsconfig.GenerateTailCalls then "--tailcalls+" else "--tailcalls-"
        yield match project.CompileTarget with
-             | CompileTarget.Library -> "--target:library" 
-             | CompileTarget.Module -> "--target:module" 
+             | CompileTarget.Library -> "--target:library"
+             | CompileTarget.Module -> "--target:module"
              | _ -> "--target:exe"
        // TODO: This currently ignores escaping using "..."
        for arg in fsconfig.OtherFlags.Split([| ' ' |], StringSplitOptions.RemoveEmptyEntries) do
-         yield arg 
-       yield! dashr 
-       yield! files] 
+         yield arg
+       yield! dashr
+       yield! files]
 
   let generateProjectOptions (project:DotNetProject, fsconfig:FSharpCompilerParameters, reqLangVersion, targetFramework, configSelector, shouldWrap) =
     let compilerOptions = generateCompilerOptions (project, fsconfig, reqLangVersion, targetFramework, configSelector, shouldWrap) |> Array.ofSeq
@@ -457,13 +457,13 @@ module CompilerArguments =
       match MonoDevelop.Ide.IdeApp.Workspace with
             | ws when ws <> null && ws.ActiveConfiguration <> null -> ws.ActiveConfiguration
             | _ -> MonoDevelop.Projects.ConfigurationSelector.Default
-       
+
   let getArgumentsFromProject (proj:DotNetProject) =
         let config = getConfig()
         let projConfig = proj.GetConfiguration(config) :?> DotNetProjectConfiguration
         let fsconfig = projConfig.CompilationParameters :?> FSharpCompilerParameters
         generateProjectOptions (proj, fsconfig, None, getTargetFramework projConfig.TargetFramework.Id, config, false)
-        
+
   let getReferencesFromProject (proj:DotNetProject) =
         let config = getConfig()
         let projConfig = proj.GetConfiguration(config) :?> DotNetProjectConfiguration


### PR DESCRIPTION
project.GetReferencedAssemblies was added back. It was needed for assemblies resolved externally with MSBuild.

Needed to put back the project options cache too to prevent deadlocking when creating a new Xamarin Forms solution. Need to revisit this.